### PR TITLE
Create .catar files with the permission of origin

### DIFF
--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -231,6 +231,14 @@ static int make(int argc, char *argv[]) {
         }
         input_fd = -1;
 
+        if (output) {
+                r = ca_sync_set_make_perm_mode(s, st.st_mode & 0666);
+                if (r < 0) {
+                        fprintf(stderr, "Failed to set make permission mode: %s\n", strerror(-r));
+                        goto finish;
+                }
+        }
+
         if (operation == MAKE_ARCHIVE) {
                 if (output)
                         r = ca_sync_set_archive_path(s, output);

--- a/src/casync.c
+++ b/src/casync.c
@@ -38,6 +38,7 @@ typedef struct CaSync {
         char *temporary_archive_path;
 
         mode_t base_mode;
+        mode_t make_perm_mode;
 
         ReallocBuffer buffer;
 
@@ -58,6 +59,7 @@ static CaSync *ca_sync_new(void) {
 
         s->base_fd = s->archive_fd = -1;
         s->base_mode = (mode_t) -1;
+        s->make_perm_mode = (mode_t) -1;
 
         return s;
 }
@@ -237,6 +239,21 @@ int ca_sync_set_base_path(CaSync *s, const char *path) {
         return 0;
 }
 
+int ca_sync_set_make_perm_mode(CaSync *s, mode_t m) {
+        if (!s)
+                return -EINVAL;
+        if (m & ~(S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH))
+                return -EINVAL;
+        if (s->direction != CA_SYNC_ENCODE)
+                return -ENOTTY;
+
+        if (s->make_perm_mode != (mode_t) -1)
+                return -EBUSY;
+
+        s->make_perm_mode = m;
+        return 0;
+}
+
 int ca_sync_set_base_mode(CaSync *s, mode_t m) {
         if (!s)
                 return -EINVAL;
@@ -360,14 +377,14 @@ static int ca_sync_start(CaSync *s) {
         assert(s);
 
         if (s->direction == CA_SYNC_ENCODE && s->archive_path && s->archive_fd < 0) {
-
                 if (!s->temporary_archive_path) {
                         r = tempfn_random(s->archive_path, &s->temporary_archive_path);
                         if (r < 0)
                                 return r;
                 }
 
-                s->archive_fd = open(s->temporary_archive_path, O_WRONLY|O_CLOEXEC|O_NOCTTY|O_CREAT|O_EXCL, 0777);
+                s->archive_fd = open(s->temporary_archive_path, O_WRONLY|O_CLOEXEC|O_NOCTTY|O_CREAT|O_EXCL,
+                                     s->make_perm_mode & 0666);
                 if (s->archive_fd < 0) {
                         s->temporary_archive_path = mfree(s->temporary_archive_path);
                         return -errno;

--- a/src/casync.h
+++ b/src/casync.h
@@ -24,6 +24,7 @@ int ca_sync_set_index_path(CaSync *sync, const char *path);
 /* The raw, unarchived ("user") tree */
 int ca_sync_set_base_fd(CaSync *sync, int fd);
 int ca_sync_set_base_path(CaSync *sync, const char *path);
+int ca_sync_set_make_perm_mode(CaSync *sync, mode_t mode);
 int ca_sync_set_base_mode(CaSync *sync, mode_t mode);
 
 /* The serialization of the user tree */


### PR DESCRIPTION
This makes sure that sensitive files stay sensitive.