### PR TITLE
caencoder: add basic file system header parser

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -156,6 +156,7 @@ static inline uint64_t random_u64(void) {
 #define _unlikely_(x) (__builtin_expect(!!(x),0))
 #define _malloc_ __attribute__ ((malloc))
 #define _pure_ __attribute__ ((pure))
+#define _packed_ __attribute__ ((packed))
 #ifdef __clang__
 #  define _alloc_(...)
 #else


### PR DESCRIPTION
When operating on a block device, let's read the first 4 bytes and see if we
can detect a file system. If that's the case, determine the number of bytes
worth reading from that source.

This patch implements the squashfs reader only, but other types could easily
be added.