### PR TITLE
encoder: fix two image size detection issues

### DIFF
--- a/src/caencoder.c
+++ b/src/caencoder.c
@@ -329,7 +329,7 @@ static int ca_encoder_node_read_device_size(CaEncoderNode *n) {
 
         switch(le32toh(superblock.magic)) {
                 case SQUASHFS_MAGIC:
-                        n->device_size = le64toh(superblock.squashfs.bytes_used);
+                        n->device_size = ALIGN_TO(le64toh(superblock.squashfs.bytes_used), 4096UL);
                         return 1;
 
                 case _ANDROID_BOOTIMG_MAGIC_1:

--- a/src/caencoder.c
+++ b/src/caencoder.c
@@ -309,6 +309,11 @@ static int ca_encoder_node_read_device_size(CaEncoderNode *n) {
                                 le32_t second_size;
                                 unsigned int second_addr;
 
+                                unsigned int tags_addr;
+                                le32_t page_size;
+
+                                le32_t dtb_size;
+
                                 /* ignore the rest */
                         } _packed_ android_bootimg;
                 };
@@ -334,10 +339,13 @@ static int ca_encoder_node_read_device_size(CaEncoderNode *n) {
 
                 case _ANDROID_BOOTIMG_MAGIC_1:
                         if (le32toh(superblock.android_bootimg.magic2) == _ANDROID_BOOTIMG_MAGIC_2) {
-                                n->device_size = 608 /* header size */ +
-                                                 le32toh(superblock.android_bootimg.kernel_size) +
-                                                 le32toh(superblock.android_bootimg.initrd_size) +
-                                                 le32toh(superblock.android_bootimg.second_size);
+                                uint32_t pagesize = le32toh(superblock.android_bootimg.page_size);
+
+                                n->device_size = ALIGN_TO(608, pagesize) /* header size */ +
+                                                 ALIGN_TO(le32toh(superblock.android_bootimg.kernel_size), pagesize) +
+                                                 ALIGN_TO(le32toh(superblock.android_bootimg.initrd_size), pagesize) +
+                                                 ALIGN_TO(le32toh(superblock.android_bootimg.second_size), pagesize) +
+                                                 ALIGN_TO(le32toh(superblock.android_bootimg.dtb_size), pagesize);
                                 return 1;
                         }
 


### PR DESCRIPTION
squashfs images are usually aligned to 4096 bytes unless explicitly
stated otherwise. In the latter case, however, seeding the last bytes
of the block device doesn't harm, so let's always do that.