### PR TITLE
meson: make fuse support optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -92,19 +92,26 @@ docdir = join_paths(datadir, 'doc/casync')
 protocoldir = join_paths(prefixdir, 'lib/casync/protocols')
 conf.set_quoted('CASYNC_PROTOCOL_PATH', protocoldir)
 
-config_h = configure_file(
-        output : 'config.h',
-        configuration : conf)
-add_project_arguments('-include', 'config.h', language : 'c')
-
 liblzma = dependency('liblzma',
                      version : '>= 5.1.0')
 libcurl = dependency('libcurl',
                      version : '>= 7.32.0')
-libfuse = dependency('fuse',
-                     version : '>= 2.6')
+
 libgcrypt = cc.find_library('gcrypt')
 libacl = cc.find_library('acl')
+
+if get_option('fuse')
+        libfuse = dependency('fuse',
+                             version : '>= 2.6')
+else
+        libfuse = []
+endif
+conf.set10('HAVE_FUSE', get_option('fuse'))
+
+config_h = configure_file(
+        output : 'config.h',
+        configuration : conf)
+add_project_arguments('-include', 'config.h', language : 'c')
 
 subdir('src')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+# -*- mode: meson -*-
+
+option('fuse', type : 'boolean', value : true,
+       description : 'build the fuse backend (requires fuse-devel)')

--- a/src/cafuse.h
+++ b/src/cafuse.h
@@ -3,6 +3,8 @@
 
 #include "casync.h"
 
+#if HAVE_FUSE
 int ca_fuse_run(CaSync *s, const char *what, const char *where, bool do_mkdir);
+#endif
 
 #endif

--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -81,7 +81,9 @@ static void help(void) {
                "%1$s [OPTIONS...] mtree [ARCHIVE|ARCHIVE_INDEX|DIRECTORY]\n"
                "%1$s [OPTIONS...] stat [ARCHIVE|ARCHIVE_INDEX|DIRECTORY] [PATH]\n"
                "%1$s [OPTIONS...] digest [ARCHIVE|BLOB|ARCHIVE_INDEX|BLOB_INDEX|DIRECTORY]\n"
+#if HAVE_FUSE
                "%1$s [OPTIONS...] mount [ARCHIVE|ARCHIVE_INDEX] PATH\n"
+#endif
                "%1$s [OPTIONS...] mkdev [BLOB|BLOB_INDEX] [NODE]\n\n"
                "Content-Addressable Data Synchronization Tool\n\n"
                "  -h --help                  Show this help\n"
@@ -98,7 +100,9 @@ static void help(void) {
                "     --punch-holes=no        Don't create sparse files\n"
                "     --reflink=no            Don't create reflinks from seeds\n"
                "     --seed-output=no        Don't implicitly add pre-existing output as seed\n"
+#if HAVE_FUSE
                "     --mkdir=no              Don't automatically create mount directory if it is missing\n"
+#endif
                "     --uid-shift=yes|SHIFT   Shift UIDs/GIDs\n"
                "     --uid-range=RANGE       Restrict UIDs/GIDs to range\n\n"
                "Input/output selector:\n"
@@ -2452,7 +2456,7 @@ finish:
 }
 
 static int verb_mount(int argc, char *argv[]) {
-
+#if HAVE_FUSE
         typedef enum MountOperation {
                 MOUNT_ARCHIVE,
                 MOUNT_ARCHIVE_INDEX,
@@ -2570,6 +2574,10 @@ finish:
         free(input);
 
         return r;
+#else
+        fprintf(stderr, "Compiled without support for fuse.\n");
+        return -ENOSYS;
+#endif
 }
 
 static int verb_mkdev(int argc, char *argv[]) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -65,8 +65,11 @@ casync_sources = files('''
         casync-tool.c
 	canbd.c
 	canbd.h
-	cafuse.c
 	cafuse.h
 '''.split())
+
+if conf.get('HAVE_FUSE') == 1
+        casync_sources += files('cafuse.c')
+endif
 
 casync_http_sources = files('casync-http.c')


### PR DESCRIPTION
No autodetection is performed. -Dfuse=false can be used to disable fuse
support.

fuse-related options are not advertised, but they are still understood
(and fail immediately).