### PR TITLE
tool: fix compilation error

### DIFF
--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <sys/sysmacros.h>
 #include <sys/stat.h>
+#include <time.h>
 
 #include "cachunk.h"
 #include "caformat-util.h"


### PR DESCRIPTION
Looks like it was broken since 88b94e1
```
../src/casync-tool.c: In function ‘verb_list’:
../src/casync-tool.c:1996:51: error: storage size of ‘tm’ isn’t known
                                         struct tm tm;
                                                   ^~
../src/casync-tool.c:1999:45: error: implicit declaration of function ‘localtime_r’ [-Werror=implicit-function-declaration]
                                         if (localtime_r(&t, &tm) &&
                                             ^~~~~~~~~~~
../src/casync-tool.c:1999:45: warning: nested extern declaration of ‘localtime_r’ [-Wnested-externs]
../src/casync-tool.c:2000:45: error: implicit declaration of function ‘strftime’ [-Werror=implicit-function-declaration]
                                             strftime(d, sizeof(d), "%Y-%m-%d %H:%M:%S", &tm) > 0)
                                             ^~~~~~~~
../src/casync-tool.c:2000:45: warning: incompatible implicit declaration of built-in function ‘strftime’
../src/casync-tool.c:2000:45: note: include ‘<time.h>’ or provide a declaration of ‘strftime’
../src/casync-tool.c:1996:51: warning: unused variable ‘tm’ [-Wunused-variable]
                                         struct tm tm;
                                                   ^~
```