### PR TITLE
casync: Fix declaration of ca_origin_advance_bytes

### DIFF
--- a/src/caorigin.h
+++ b/src/caorigin.h
@@ -26,7 +26,7 @@ int ca_origin_concat(CaOrigin *origin, CaOrigin *other, uint64_t n_bytes);
 int ca_origin_put_void(CaOrigin *origin, uint64_t n_bytes);
 
 int ca_origin_advance_items(CaOrigin *origin, size_t n_drop);
-int ca_origin_advance_bytes(CaOrigin *origin, size_t n_bytes);
+int ca_origin_advance_bytes(CaOrigin *origin, uint64_t n_bytes);
 
 int ca_origin_dump(FILE *f, CaOrigin *origin);
 


### PR DESCRIPTION
Fixes build failure on 32 bit:
```
../src/caorigin.c:208:5: error: conflicting types for ‘ca_origin_advance_bytes’
 int ca_origin_advance_bytes(CaOrigin *origin, uint64_t n_bytes) {
     ^~~~~~~~~~~~~~~~~~~~~~~
In file included from ../src/caorigin.c:1:0:
../src/caorigin.h:29:5: note: previous declaration of ‘ca_origin_advance_bytes’ was here
 int ca_origin_advance_bytes(CaOrigin *origin, size_t n_bytes);
```