### PR TITLE
README: add borg

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ implemented in a variety of other projects, and puts them together in a
 moderately new, nice way. That's all. The primary influences are rsync and git,
 but there are other systems that use similar algorithms, in particular:
 
+- BorgBackup (http://www.borgbackup.org/)
 - bup (https://bup.github.io/)
 - CAFS (https://github.com/indyjo/cafs)
 - dedupfs (https://github.com/xolox/dedupfs)


### PR DESCRIPTION
borg is [under the hood](http://borgbackup.readthedocs.io/en/latest/internals.html) very similar to casync;

- packs metadata into a stream, like tar and casync
- metadata stream is chunked and globally deduplicated
- file data is chunked and globally deduplicated
- also uses buzhash (though I'm not 100% convinced it's a good choice for a new project,
  it's quite limited in terms of performance — I've done only limited testing on this idea
  but giving up byte-granularity and instead using 4-8 byte granularity is a rather large performance
  improvement, with at least in my tests little impact on deduplication).

  At this time it is still _sufficient_ though, at least in a multi-threaded context.
- uses SHA-256 (in 1.0)... it'd probably be better to use something different
  in a new project, e.g. SHA-512-256 or Blake2 or one of the heavily advertised
  Keccak-derivates.

An interesting difference is that casync is more like tar, since the tree
is turned into *one* stream which is then chunked, while Borg generates
a metadata stream (sans file contents) and references file data from there;
file contents and metadata are separate.

That's a really interesting choice and it'd be interesting to see what exactly the impact
of it is. I think that brings the number of principal storage methods in deduplicating archives
 to ~three:

- git/restic-like: file tree is transformed into an object tree
- borg: file tree is transformed into metadata stream, file contents are separate
- casync: file tree is transformed into stream (tar-like)

With 1) vs. 2) there are clear up- and downsides to each, 2) vs. 3) is not so clear. I'd guess
that metadata querying ("ls archive") with 3) is not as efficient, since data can't be skipped.
Deduplication is always hard to tell from theory. 3) enables the efficient composition,
which is very, very difficult in 1) and still not easy in 2).

Anyway, this is very interesting news!