### PR TITLE
Ioctl fixes

### DIFF
--- a/src/cadecoder.c
+++ b/src/cadecoder.c
@@ -3642,7 +3642,7 @@ static int ca_decoder_finalize_child(CaDecoder *d, CaDecoderNode *n, CaDecoderNo
         }
 
         if ((d->feature_flags & CA_FORMAT_WITH_CHATTR) != 0 && child->fd >= 0) {
-                unsigned new_attr, old_attr;
+                int new_attr, old_attr;
 
                 new_attr = ca_feature_flags_to_chattr(read_le64(&child->entry->flags) & d->feature_flags);
 
@@ -4471,7 +4471,7 @@ int ca_decoder_current_rdev(CaDecoder *d, dev_t *ret) {
         return 0;
 }
 
-int ca_decoder_current_chattr(CaDecoder *d, unsigned *ret) {
+int ca_decoder_current_chattr(CaDecoder *d, int *ret) {
         CaDecoderNode *n;
         mode_t mode;
 

--- a/src/cadecoder.h
+++ b/src/cadecoder.h
@@ -89,7 +89,7 @@ int ca_decoder_current_user(CaDecoder *d, const char **user);
 int ca_decoder_current_group(CaDecoder *d, const char **user);
 int ca_decoder_current_rdev(CaDecoder *d, dev_t *ret);
 int ca_decoder_current_offset(CaDecoder *d, uint64_t *ret);
-int ca_decoder_current_chattr(CaDecoder *d, unsigned *ret);
+int ca_decoder_current_chattr(CaDecoder *d, int *ret);
 int ca_decoder_current_fat_attrs(CaDecoder *d, uint32_t *ret);
 int ca_decoder_current_xattr(CaDecoder *d, CaIterate where, const char **ret_name, const void **ret_value, size_t *ret_size);
 

--- a/src/caencoder.c
+++ b/src/caencoder.c
@@ -2850,7 +2850,7 @@ int ca_encoder_current_rdev(CaEncoder *e, dev_t *ret) {
         return 0;
 }
 
-int ca_encoder_current_chattr(CaEncoder *e, unsigned *ret) {
+int ca_encoder_current_chattr(CaEncoder *e, int *ret) {
         CaEncoderNode *n;
 
         if (!e)

--- a/src/caencoder.h
+++ b/src/caencoder.h
@@ -49,7 +49,7 @@ int ca_encoder_current_gid(CaEncoder *e, gid_t *ret);
 int ca_encoder_current_user(CaEncoder *e, const char **ret);
 int ca_encoder_current_group(CaEncoder *e, const char **ret);
 int ca_encoder_current_rdev(CaEncoder *e, dev_t *ret);
-int ca_encoder_current_chattr(CaEncoder *e, unsigned *ret);
+int ca_encoder_current_chattr(CaEncoder *e, int *ret);
 int ca_encoder_current_fat_attrs(CaEncoder *e, uint32_t *ret);
 int ca_encoder_current_xattr(CaEncoder *e, CaIterate where, const char **ret_name, const void **ret_value, size_t *ret_size);
 

--- a/src/caformat-util.c
+++ b/src/caformat-util.c
@@ -283,10 +283,9 @@ unsigned ca_feature_flags_to_chattr(uint64_t flags) {
         unsigned f = 0;
         size_t i;
 
-        for (i = 0; i < ELEMENTSOF(chattr_map); i++) {
+        for (i = 0; i < ELEMENTSOF(chattr_map); i++)
                 if (flags & chattr_map[i].feature_flag)
                         f |= chattr_map[i].chattr_flag;
-        }
 
         return f;
 }
@@ -315,10 +314,9 @@ uint32_t ca_feature_flags_to_fat_attrs(uint64_t flags) {
         uint32_t f = 0;
         size_t i;
 
-        for (i = 0; i < ELEMENTSOF(fat_attrs_map); i++) {
+        for (i = 0; i < ELEMENTSOF(fat_attrs_map); i++)
                 if (flags & fat_attrs_map[i].feature_flag)
                         f |= fat_attrs_map[i].fat_flag;
-        }
 
         return f;
 }

--- a/src/caformat-util.c
+++ b/src/caformat-util.c
@@ -279,8 +279,8 @@ uint64_t ca_feature_flags_from_chattr(unsigned flags) {
         return f;
 }
 
-unsigned ca_feature_flags_to_chattr(uint64_t flags) {
-        unsigned f = 0;
+int ca_feature_flags_to_chattr(uint64_t flags) {
+        int f = 0;
         size_t i;
 
         for (i = 0; i < ELEMENTSOF(chattr_map); i++)

--- a/src/caformat-util.h
+++ b/src/caformat-util.h
@@ -14,7 +14,7 @@ int ca_feature_flags_normalize(uint64_t flags, uint64_t *ret);
 int ca_feature_flags_time_granularity_nsec(uint64_t flags, uint64_t *ret);
 
 uint64_t ca_feature_flags_from_chattr(unsigned flags);
-unsigned ca_feature_flags_to_chattr(uint64_t flags);
+int ca_feature_flags_to_chattr(uint64_t flags);
 
 uint64_t ca_feature_flags_from_fat_attrs(uint32_t flags);
 uint32_t ca_feature_flags_to_fat_attrs(uint64_t flags);

--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -2058,7 +2058,7 @@ static int verb_list(int argc, char *argv[]) {
                                 uid_t uid = UID_INVALID;
                                 gid_t gid = GID_INVALID;
                                 dev_t rdev = (dev_t) -1;
-                                unsigned flags = (unsigned) -1;
+                                int flags = -1;
                                 uint32_t fat_attrs = (uint32_t) -1;
                                 char *escaped = NULL;
                                 const char *xname;
@@ -2093,7 +2093,7 @@ static int verb_list(int argc, char *argv[]) {
 
                                 escaped = mfree(escaped);
 
-                                if (flags != (unsigned) -1)
+                                if (flags != -1)
                                         printf("FileAttr: %s\n", strna(ls_format_chattr(flags, ls_flags)));
 
                                 if (fat_attrs != (uint32_t) -1)

--- a/src/casync.c
+++ b/src/casync.c
@@ -2943,7 +2943,7 @@ int ca_sync_current_rdev(CaSync *s, dev_t *ret) {
         return -ENOTTY;
 }
 
-int ca_sync_current_chattr(CaSync *s, unsigned *ret) {
+int ca_sync_current_chattr(CaSync *s, int *ret) {
         CaSeed *seed;
 
         if (!s)

--- a/src/casync.h
+++ b/src/casync.h
@@ -96,7 +96,7 @@ int ca_sync_current_group(CaSync *sync, const char **ret);
 int ca_sync_current_mtime(CaSync *sync, uint64_t *nsec);
 int ca_sync_current_size(CaSync *sync, uint64_t *ret);
 int ca_sync_current_rdev(CaSync *sync, dev_t *ret);
-int ca_sync_current_chattr(CaSync *sync, unsigned *ret);
+int ca_sync_current_chattr(CaSync *sync, int *ret);
 int ca_sync_current_fat_attrs(CaSync *sync, uint32_t *ret);
 int ca_sync_current_xattr(CaSync *sync, CaIterate where, const char **ret_name, const void **ret_value, size_t *ret_size);
 

--- a/src/util.c
+++ b/src/util.c
@@ -672,10 +672,10 @@ char* ls_format_mode(mode_t m, char ret[LS_FORMAT_MODE_MAX]) {
         return ret;
 }
 
-char *ls_format_chattr(unsigned flags, char ret[LS_FORMAT_CHATTR_MAX]) {
+char *ls_format_chattr(int flags, char ret[LS_FORMAT_CHATTR_MAX]) {
 
         static const struct {
-                unsigned flag;
+                int flag;
                 char code;
         } table[] = {
                 { FS_SYNC_FL,        'S' },
@@ -692,7 +692,7 @@ char *ls_format_chattr(unsigned flags, char ret[LS_FORMAT_CHATTR_MAX]) {
 
         size_t i;
 
-        if (flags == (unsigned) -1)
+        if (flags == -1)
                 return NULL;
 
         assert(ELEMENTSOF(table) == LS_FORMAT_CHATTR_MAX-1);

--- a/src/util.h
+++ b/src/util.h
@@ -487,6 +487,8 @@ static inline bool strv_isempty(char **l) {
 #      define __NR_renameat2 353
 #    elif defined __powerpc64__
 #      define __NR_renameat2 357
+#    elif defined __s390__ || defined __s390__
+#      define __NR_renameat2 347
 #    else
 #      warning "__NR_renameat2 unknown for your architecture"
 #    endif

--- a/src/util.h
+++ b/src/util.h
@@ -485,6 +485,8 @@ static inline bool strv_isempty(char **l) {
 #      endif
 #    elif defined __i386__
 #      define __NR_renameat2 353
+#    elif defined __powerpc64__
+#      define __NR_renameat2 357
 #    else
 #      warning "__NR_renameat2 unknown for your architecture"
 #    endif

--- a/src/util.h
+++ b/src/util.h
@@ -46,6 +46,15 @@
                 UNIQ_T(A,aq) < UNIQ_T(B,bq) ? UNIQ_T(A,aq) : UNIQ_T(B,bq); \
         })
 
+
+/* "linux/fs.h" contains wrong definitions of FS_IOC_[GS]ETFLAGS.
+ * This problem has been known for at least 14 years. To avoid a spurious
+ * warning from valgrind, let's override the kernel definitions. */
+#undef FS_IOC_GETFLAGS
+#undef FS_IOC_SETFLAGS
+#define FS_IOC_GETFLAGS                 _IOR('f', 1, int)
+#define FS_IOC_SETFLAGS                 _IOW('f', 2, int)
+
 static inline uint64_t timespec_to_nsec(struct timespec t) {
 
         if (t.tv_sec == (time_t) -1 &&
@@ -285,7 +294,7 @@ char *strjoin_real(const char *x, ...) _sentinel_;
 char* ls_format_mode(mode_t m, char ret[LS_FORMAT_MODE_MAX]);
 
 #define LS_FORMAT_CHATTR_MAX 11
-char *ls_format_chattr(unsigned flags, char ret[LS_FORMAT_CHATTR_MAX]);
+char *ls_format_chattr(int flags, char ret[LS_FORMAT_CHATTR_MAX]);
 
 #define LS_FORMAT_FAT_ATTRS_MAX 4
 char *ls_format_fat_attrs(unsigned flags, char ret[LS_FORMAT_FAT_ATTRS_MAX]);

--- a/test/test-script.sh.in
+++ b/test/test-script.sh.in
@@ -13,10 +13,10 @@ SCRATCH_DIR=/var/tmp/test-casync.$RANDOM
 mkdir -p $SCRATCH_DIR/src
 
 if [ `id -u` == 0 ] ; then
-    cp -a @top_srcdir@ $SCRATCH_DIR/src
+    cp -a @top_srcdir@/test-files $SCRATCH_DIR/src/
 else
     # If we lack privileges we use rsync rather than cp to copy, as it will just skip over device nodes
-    rsync -a @top_srcdir@ $SCRATCH_DIR/src
+    rsync -a @top_srcdir@/test-files $SCRATCH_DIR/src/
 fi
 
 cd $SCRATCH_DIR/src
@@ -101,17 +101,17 @@ diff -q $SCRATCH_DIR/test.digest $SCRATCH_DIR/test.extract-caidx2.digest
 @top_builddir@/casync $PARAMS make $SCRATCH_DIR/seek.catar
 @top_builddir@/casync $PARAMS make $SCRATCH_DIR/seek.caidx
 
-@top_builddir@/casync $PARAMS extract $SCRATCH_DIR/seek.catar $SCRATCH_DIR/extract-seek-catar casync/test-files
-@top_builddir@/casync $PARAMS extract $SCRATCH_DIR/seek.caidx $SCRATCH_DIR/extract-seek-caidx casync/test-files
+@top_builddir@/casync $PARAMS extract $SCRATCH_DIR/seek.catar $SCRATCH_DIR/extract-seek-catar test-files
+@top_builddir@/casync $PARAMS extract $SCRATCH_DIR/seek.caidx $SCRATCH_DIR/extract-seek-caidx test-files
 
-@top_builddir@/casync $PARAMS mtree casync/test-files > $SCRATCH_DIR/original-seek.mtree
-@top_builddir@/casync $PARAMS digest casync/test-files > $SCRATCH_DIR/original-seek.digest
+@top_builddir@/casync $PARAMS mtree test-files > $SCRATCH_DIR/original-seek.mtree
+@top_builddir@/casync $PARAMS digest test-files > $SCRATCH_DIR/original-seek.digest
 @top_builddir@/casync $PARAMS mtree $SCRATCH_DIR/extract-seek-catar/test-files > $SCRATCH_DIR/extract-seek-catar.mtree
 @top_builddir@/casync $PARAMS digest $SCRATCH_DIR/extract-seek-catar/test-files > $SCRATCH_DIR/extract-seek-catar.digest
 @top_builddir@/casync $PARAMS mtree $SCRATCH_DIR/extract-seek-caidx/test-files > $SCRATCH_DIR/extract-seek-caidx.mtree
 @top_builddir@/casync $PARAMS digest $SCRATCH_DIR/extract-seek-caidx/test-files > $SCRATCH_DIR/extract-seek-caidx.digest
-@top_builddir@/casync $PARAMS digest $SCRATCH_DIR/seek.catar casync/test-files > $SCRATCH_DIR/extract-seek-catar-direct.digest
-@top_builddir@/casync $PARAMS digest $SCRATCH_DIR/seek.caidx casync/test-files > $SCRATCH_DIR/extract-seek-caidx-direct.digest
+@top_builddir@/casync $PARAMS digest $SCRATCH_DIR/seek.catar test-files > $SCRATCH_DIR/extract-seek-catar-direct.digest
+@top_builddir@/casync $PARAMS digest $SCRATCH_DIR/seek.caidx test-files > $SCRATCH_DIR/extract-seek-caidx-direct.digest
 
 diff -q $SCRATCH_DIR/original-seek.digest $SCRATCH_DIR/extract-seek-catar.digest
 diff -q $SCRATCH_DIR/original-seek.digest $SCRATCH_DIR/extract-seek-caidx.digest


### PR DESCRIPTION
This makes tests pass on ext4, with 4.11 kernel. With 4.12-rc kernel they were already passing, but maybe it was for a different reason.

In Fedora koji (https://koji.fedoraproject.org/koji/taskinfo?taskID=20073290):
```
amd64:
 1/12 test-script.sh                          FAIL    14.76 s
 2/12 test-nbd.sh                             OK      10.00 s
 3/12 test-fuse.sh                            OK      12.53 s
 4/12 test-cachunk                            OK       0.39 s
 5/12 test-cachunker                          OK       0.70 s
 6/12 test-cachunker-histogram                OK       2.03 s
 7/12 test-caencoder                          OK       0.02 s
 8/12 test-camakebst                          OK       2.95 s
 9/12 test-caorigin                           OK       0.00 s
10/12 test-casync                             OK       9.83 s
11/12 test-cautil                             OK       0.00 s
12/12 test-util                               OK       0.00 s

ppc64le:
 1/12 test-script.sh                          FAIL    15.95 s
 2/12 test-nbd.sh                             OK       7.46 s
 3/12 test-fuse.sh                            OK      12.26 s
 4/12 test-cachunk                            OK       0.30 s
 5/12 test-cachunker                          OK       0.29 s
 6/12 test-cachunker-histogram                OK       2.01 s
 7/12 test-caencoder                          OK       0.02 s
 8/12 test-camakebst                          OK       2.72 s
 9/12 test-caorigin                           OK       0.01 s
10/12 test-casync                             OK       8.56 s
11/12 test-cautil                             OK       0.01 s
12/12 test-util                               OK       0.03 s

arm64:
 1/12 test-script.sh                          FAIL    23.80 s
 2/12 test-nbd.sh                             OK       9.61 s
 3/12 test-fuse.sh                            OK      17.73 s
 4/12 test-cachunk                            OK       0.56 s
 5/12 test-cachunker                          OK       0.69 s
 6/12 test-cachunker-histogram                OK       2.05 s
 7/12 test-caencoder                          OK       0.05 s
 8/12 test-camakebst                          OK       3.92 s
 9/12 test-caorigin                           OK       0.01 s
10/12 test-casync                             OK      12.25 s
11/12 test-cautil                             OK       0.01 s
12/12 test-util                               OK       0.01 s

ppc64be:
 1/12 test-script.sh                          FAIL     0.44 s
 2/12 test-nbd.sh                             FAIL     7.02 s
 3/12 test-fuse.sh                            FAIL    10.86 s
 4/12 test-cachunk                            OK       0.31 s
 5/12 test-cachunker                          OK       1.78 s
 6/12 test-cachunker-histogram                OK       2.02 s
 7/12 test-caencoder                          OK       0.09 s
 8/12 test-camakebst                          OK       3.78 s
 9/12 test-caorigin                           OK       0.00 s
10/12 test-casync                             FAIL     7.75 s
11/12 test-cautil                             OK       0.01 s
12/12 test-util                               OK       0.03 s

i386:
 1/12 test-script.sh                          FAIL    10.35 s
 2/12 test-nbd.sh                             FAIL     8.70 s
 3/12 test-fuse.sh                            OK      11.49 s
 4/12 test-cachunk                            OK       0.44 s
 5/12 test-cachunker                          OK       2.03 s
 6/12 test-cachunker-histogram                OK       2.02 s
 7/12 test-caencoder                          OK       0.03 s
 8/12 test-camakebst                          OK       3.11 s
 9/12 test-caorigin                           OK       0.01 s
10/12 test-casync                             FAIL     7.48 s
11/12 test-cautil                             OK       0.01 s
12/12 test-util                               OK       0.01 s

s390x:
 1/12 test-script.sh                          FAIL     0.35 s
 2/12 test-nbd.sh                             FAIL     0.16 s
 3/12 test-fuse.sh                            FAIL     0.24 s
 4/12 test-cachunk                            OK       0.32 s
 5/12 test-cachunker                          OK       1.43 s
 6/12 test-cachunker-histogram                OK       2.03 s
 7/12 test-caencoder                          OK       0.08 s
 8/12 test-camakebst                          OK       3.11 s
 9/12 test-caorigin                           OK       0.00 s
10/12 test-casync                             FAIL     0.14 s
11/12 test-cautil                             OK       0.00 s
12/12 test-util                               OK       0.00 s

arm:
 1/12 test-script.sh                          FAIL    54.35 s
 2/12 test-nbd.sh                             FAIL    43.99 s
 3/12 test-fuse.sh                            OK      58.42 s
 4/12 test-cachunk                            OK       1.43 s
 5/12 test-cachunker                          OK       2.00 s
 6/12 test-cachunker-histogram                OK       2.07 s
 7/12 test-caencoder                          OK       0.12 s
 8/12 test-camakebst                          OK       5.53 s
 9/12 test-caorigin                           OK       0.02 s
10/12 test-casync                             TIMEOUT 30.06 s
11/12 test-cautil                             OK       0.02 s
12/12 test-util                               OK       0.02 s
```
It seems that there are still endianness and 32bit issues.