### PR TITLE
tests: fix tests when the source directory is not called "casync"

### DIFF
--- a/test/test-script.sh.in
+++ b/test/test-script.sh.in
@@ -13,10 +13,10 @@ SCRATCH_DIR=/var/tmp/test-casync.$RANDOM
 mkdir -p $SCRATCH_DIR/src
 
 if [ `id -u` == 0 ] ; then
-    cp -a @top_srcdir@ $SCRATCH_DIR/src
+    cp -aT @top_srcdir@ $SCRATCH_DIR/src/casync
 else
     # If we lack privileges we use rsync rather than cp to copy, as it will just skip over device nodes
-    rsync -a @top_srcdir@ $SCRATCH_DIR/src
+    rsync -a @top_srcdir@/ $SCRATCH_DIR/src/casync
 fi
 
 cd $SCRATCH_DIR/src


### PR DESCRIPTION
test-script.sh would fail when the top source dir was called e.g. casync-1.