### PR TITLE
tests: Add 32 bit run to semaphore

### DIFF
--- a/test/semaphore-run
+++ b/test/semaphore-run
@@ -1,18 +1,48 @@
 #!/bin/sh
+DEVPKGS="pkg-config liblzma-dev libcurl4-gnutls-dev libgcrypt-dev libacl1-dev libfuse-dev "
+
+echo
+echo "============= Installing amd64 build dependencies =============="
 set -eu
 sudo apt-get install -y software-properties-common
 sudo add-apt-repository -y ppa:pitti/systemd-semaphore
+sudo dpkg --add-architecture i386
 sudo apt-get update
 
-sudo apt-get install -y pkg-config liblzma-dev libcurl4-gnutls-dev libgcrypt-dev libacl1-dev libfuse-dev rsync python3 meson
+sudo apt-get install -y $DEVPKGS rsync python3 meson
 
+echo
+echo "============= Building amd64 =============="
 meson build
 ninja -C build
 
 echo
-echo "============= Running tests as user =============="
+echo "============= Running amd64 tests as user =============="
 ninja -C build test
 
 echo
-echo "============= Running tests as root =============="
+echo "============= Running amd64 tests as root =============="
 sudo ninja -C build test
+
+echo
+echo "============= Installing i386 build dependencies =============="
+# help apt to figure out replacing GI dependencies (we don't need them
+# anyway, but a lot of stuff is pre-installed in semaphore)
+sudo apt-get purge --auto-remove -y python3-gi gir1.2-glib-2.0
+
+# library -dev packages are not co-installable for multiple architectures,
+# so this can't go into the setup step
+sudo apt-get install -y --no-install-recommends gcc-multilib $(echo "$DEVPKGS" | sed 's/\b /:i386 /g')
+
+echo
+echo "============= Building i386 =============="
+CFLAGS=-m32 LDFLAGS=-m32 meson build-i386
+ninja -C build-i386
+
+echo
+echo "============= Running i386 tests as user =============="
+linux32 ninja -C build-i386 test
+
+echo
+echo "============= Running i386 tests as root =============="
+sudo linux32 ninja -C build-i386 test


### PR DESCRIPTION
Current master produces a lot of type warnings on 32 bit, and tests fail
with "Failed to run synchronizer: Bad message".

Add a 32 bit (i386 Debian architecture) (cross-)build and test run to
uncover these.