### PR TITLE
meson: use TAGS for the etags output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@
 /GSYMS
 /GTAGS
 /TAGS
+/tags
 /build*/

--- a/meson.build
+++ b/meson.build
@@ -258,6 +258,8 @@ if git.found()
                  ':/*.[ch]'])
         all_files = files(all_files.stdout().split())
 
-        run_target('tags', command : ['env', 'etags', '-o', '@0@/@1@'.format(meson.source_root(), 'tags')] + all_files)
-        run_target('ctags', command : ['env', 'ctags', '-o', '@0@/@1@'.format(meson.source_root(), 'tags')] + all_files)
+        run_target('tags',
+                   command : ['env', 'etags', '-o', '@0@/@1@'.format(meson.source_root(), 'TAGS')] + all_files)
+        run_target('ctags',
+                   command : ['env', 'ctags', '-o', '@0@/@1@'.format(meson.source_root(), 'tags')] + all_files)
 endif


### PR DESCRIPTION
This is confusing, but etags(1) is pretty clear:
- emacs expects TAGS file in etags format
- vi expects tags file in ctags format
and automake docs are pretty clear too:
- tags generates TAGS file
- ctags generates tags file