### PR TITLE
casync: use sha512/256 as hash function by default

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,3 +1,10 @@
+SHORT-TERM:
+* make sure we validate everything we load from local stores, too
+* support alternative compressors
+* when extracting, check that index feature flags and archive feature flags match
+* use btrfs reflink with contents checking
+* rework how default --with= and --without= are calculated, so that --except stuff doesn't leak into blob index
+
 TO MAKE IT USEFUL FOR BACKUPS:
 * encryption: aes256 of rotating hash function + HMAC for identifying chunks + individually encrypted chunks
 * speed up repeated image generation: maintain persistent cache for directory trees that permits lookups by a path location as key, returning a chunk id and "newest covering mtime"
@@ -5,7 +12,6 @@ TO MAKE IT USEFUL FOR BACKUPS:
 LATER:
 * verify
 * diff
-* save/restore btrfs file/subvol flags
 * save/restore hardlinks?
 * check fs features when restoring
 * exclude patterns

--- a/doc/casync.rst
+++ b/doc/casync.rst
@@ -31,8 +31,8 @@ This will create either a .catar archive or an .caidx index for for the given
 of output is decided based on the extension. *DIRECTORY* is optional, and
 the current directory will be used if not specified.
 
-When an .caidx file is created, a .castr storage directory will be created too
-(see ``--store=`` option).
+When a .caidx or .caibx file is created, a .castr storage directory will be
+created too (see ``--store=`` option).
 
 |
 | **casync** extract [*ARCHIVE* | *ARCHIVE_INDEX*] [*DIRECTORY*]
@@ -137,6 +137,7 @@ General options:
 --store=PATH                    The primary chunk store to use
 --extra-store=PATH              Additional chunk store to look for chunks in
 --chunk-size=<[MIN]:AVG:[MAX]>  The minimal/average/maximum number of bytes in a chunk
+--digest=<sha256|sha512-256>    The digest algorithm to use.
 --seed=PATH                     Additional file or directory to use as seed
 --rate-limit-bps=LIMIT          Maximum bandwidth in bytes/s for remote communication
 --exclude-nodump=no             Don't exclude files with chattr(1)'s +d **nodump** flag when creating archive
@@ -199,6 +200,8 @@ Individual archive features:
 --with=<flag-sync>         Store synchronous file flag
 --with=<flag-nocomp>       Store disable compression file flag
 --with=<flag-projinherit>  Store project quota inheritance flag
+--with=<subvolume>         Store btrfs subvolume information
+--with=subvolume-ro        Store btrfs subvolume read-only property
 --with=<xattrs>            Store extended file attributes
 --with=<acl>               Store file access control lists
 --with=<fcaps>             Store file capabilities

--- a/meson.build
+++ b/meson.build
@@ -202,6 +202,14 @@ test_script = find_program(test_script_sh)
 test('test-script.sh', test_script,
      timeout : 30 * 60)
 
+test_script_sha256_sh = configure_file(
+        output : 'test-script-sha256.sh',
+        input : 'test/test-script-sha256.sh.in',
+        configuration : substs)
+test_script_sha256 = find_program(test_script_sha256_sh)
+test('test-script-sha256.sh', test_script_sha256,
+     timeout : 30 * 60)
+
 test_nbd_sh = configure_file(
         output : 'test-nbd.sh',
         input : 'test/test-nbd.sh.in',
@@ -243,6 +251,7 @@ test_sources = '''
 non_test_sources = '''
         test-caformat
         test-caindex
+        test-calc-digest
 '''.split()
 
 foreach test_name : test_sources + non_test_sources

--- a/src/cachunkid.h
+++ b/src/cachunkid.h
@@ -12,7 +12,7 @@
 #define CA_CHUNK_ID_FORMAT_MAX (CA_CHUNK_ID_SIZE*2+1)
 
 typedef union CaChunkID {
-        /* For now, a SHA256 sum */
+        /* Depending on context either a SHA256 or SHA512/256 sum */
         uint8_t bytes[CA_CHUNK_ID_SIZE];
         uint64_t u64[CA_CHUNK_ID_SIZE / sizeof(uint64_t)];
 } CaChunkID;

--- a/src/cadecoder.c
+++ b/src/cadecoder.c
@@ -212,6 +212,10 @@ struct CaDecoder {
         CaDigest *payload_digest;
         CaDigest *hardlink_digest;
 
+        bool want_archive_digest:1;
+        bool want_payload_digest:1;
+        bool want_hardlink_digest:1;
+
         bool payload_digest_invalid:1;
         bool hardlink_digest_invalid:1;
 };
@@ -1551,6 +1555,22 @@ static int ca_decoder_do_seek(CaDecoder *d, CaDecoderNode *n) {
         return -ESPIPE;
 }
 
+static int ca_decoder_write_digest(CaDecoder *d, CaDigest **digest, const void *p, size_t l) {
+        int r;
+
+        if (!d)
+                return -EINVAL;
+        if (!digest)
+                return -EINVAL;
+
+        r = ca_digest_ensure_allocated(digest, ca_feature_flags_to_digest_type(d->feature_flags));
+        if (r < 0)
+                return r;
+
+        ca_digest_write(*digest, p, l);
+        return 0;
+}
+
 static int ca_decoder_parse_entry(CaDecoder *d, CaDecoderNode *n) {
         const CaFormatEntry *entry = NULL;
         const CaFormatUser *user = NULL;
@@ -2187,15 +2207,15 @@ static int ca_decoder_parse_entry(CaDecoder *d, CaDecoderNode *n) {
         ca_decoder_enter_state(d, CA_DECODER_ENTRY);
         d->step_size = offset;
 
-        ca_digest_write(d->archive_digest, realloc_buffer_data(&d->buffer), d->step_size);
+        ca_decoder_write_digest(d, &d->archive_digest, realloc_buffer_data(&d->buffer), d->step_size);
 
-        if (d->payload_digest) {
+        if (d->want_payload_digest) {
                 ca_digest_reset(d->payload_digest);
                 d->payload_digest_invalid = false;
         }
-        if (d->hardlink_digest) {
+        if (d->want_hardlink_digest) {
                 ca_digest_reset(d->hardlink_digest);
-                ca_digest_write(d->hardlink_digest, realloc_buffer_data(&d->buffer), d->step_size);
+                ca_decoder_write_digest(d, &d->hardlink_digest, realloc_buffer_data(&d->buffer), d->step_size);
                 d->hardlink_digest_invalid = false;
         }
 
@@ -2377,11 +2397,11 @@ static int ca_decoder_parse_filename(CaDecoder *d, CaDecoderNode *n) {
 
                 d->step_size = l;
 
-                if (d->archive_digest) {
+                if (d->want_archive_digest) {
                         if (arrived)
                                 ca_digest_reset(d->archive_digest);
                         else if (!seek_continues)
-                                ca_digest_write(d->archive_digest, realloc_buffer_data(&d->buffer), d->step_size);
+                                ca_decoder_write_digest(d, &d->archive_digest, realloc_buffer_data(&d->buffer), d->step_size);
                 }
 
                 return arrived ? CA_DECODER_FOUND : CA_DECODER_STEP;
@@ -2431,7 +2451,7 @@ static int ca_decoder_parse_filename(CaDecoder *d, CaDecoderNode *n) {
                 ca_decoder_enter_state(d, CA_DECODER_GOODBYE);
                 d->step_size = l;
 
-                ca_digest_write(d->archive_digest, realloc_buffer_data(&d->buffer), d->step_size);
+                ca_decoder_write_digest(d, &d->archive_digest, realloc_buffer_data(&d->buffer), d->step_size);
 
                 return CA_DECODER_STEP;
 
@@ -3847,12 +3867,12 @@ static int ca_decoder_step_node(CaDecoder *d, CaDecoderNode *n) {
                         else
                                 d->step_size = MIN(realloc_buffer_size(&d->buffer), n->size - d->payload_offset);
 
-                        if (d->archive_digest)
-                                ca_digest_write(d->archive_digest, realloc_buffer_data(&d->buffer), d->step_size);
-                        if (d->payload_digest && !d->payload_digest_invalid)
-                                ca_digest_write(d->payload_digest, realloc_buffer_data(&d->buffer), d->step_size);
-                        if (d->hardlink_digest && !d->hardlink_digest_invalid)
-                                ca_digest_write(d->hardlink_digest, realloc_buffer_data(&d->buffer), d->step_size);
+                        if (d->want_archive_digest)
+                                ca_decoder_write_digest(d, &d->archive_digest, realloc_buffer_data(&d->buffer), d->step_size);
+                        if (d->want_payload_digest && !d->payload_digest_invalid)
+                                ca_decoder_write_digest(d, &d->payload_digest, realloc_buffer_data(&d->buffer), d->step_size);
+                        if (d->want_hardlink_digest && !d->hardlink_digest_invalid)
+                                ca_decoder_write_digest(d, &d->hardlink_digest, realloc_buffer_data(&d->buffer), d->step_size);
 
                         return CA_DECODER_PAYLOAD;
                 }
@@ -3880,7 +3900,7 @@ static int ca_decoder_step_node(CaDecoder *d, CaDecoderNode *n) {
                 }
 
                 /* If the caller doesn't want the payload, and we don't need it either, but know how large it is, then let's skip over it */
-                if (!d->payload && !d->payload_digest && n->fd < 0 && n->size != UINT64_MAX) {
+                if (!d->payload && !d->want_payload_digest && n->fd < 0 && n->size != UINT64_MAX) {
 
                         d->skip_bytes = n->size - d->payload_offset;
                         ca_decoder_enter_state(d, CA_DECODER_SKIPPING);
@@ -4007,7 +4027,7 @@ static int ca_decoder_step_node(CaDecoder *d, CaDecoderNode *n) {
                 ca_decoder_reset_seek(d);
 
                 ca_digest_reset(d->archive_digest);
-                if (d->payload_digest) {
+                if (d->want_payload_digest) {
 
                         d->payload_digest_invalid = d->payload_offset > 0;
                         if (!d->payload_digest_invalid)
@@ -5020,35 +5040,43 @@ int ca_decoder_enable_archive_digest(CaDecoder *d, bool b) {
         if (!d)
                 return -EINVAL;
 
-        return ca_digest_allocate_set(&d->archive_digest, CA_DIGEST_SHA256, b);
+        d->want_archive_digest = b;
+        return 0;
 }
 
 int ca_decoder_enable_payload_digest(CaDecoder *d, bool b) {
         if (!d)
                 return -EINVAL;
 
-        return ca_digest_allocate_set(&d->payload_digest, CA_DIGEST_SHA256, b);
+        d->want_payload_digest = b;
+        return 0;
 }
 
 int ca_decoder_enable_hardlink_digest(CaDecoder *d, bool b) {
         if (!d)
                 return -EINVAL;
 
-        return ca_digest_allocate_set(&d->hardlink_digest, CA_DIGEST_SHA256, b);
+        d->want_hardlink_digest = b;
+        return 0;
 }
 
 int ca_decoder_get_archive_digest(CaDecoder *d, CaChunkID *ret) {
         const void *q;
+        int r;
 
         if (!d)
                 return -EINVAL;
         if (!ret)
                 return -EINVAL;
 
-        if (!d->archive_digest)
+        if (!d->want_archive_digest)
                 return -ENOMEDIUM;
         if (d->state != CA_DECODER_EOF)
                 return -EBUSY;
+
+        r = ca_digest_ensure_allocated(&d->archive_digest, ca_feature_flags_to_digest_type(d->feature_flags));
+        if (r < 0)
+                return r;
 
         q = ca_digest_read(d->archive_digest);
         if (!q)
@@ -5063,13 +5091,14 @@ int ca_decoder_get_payload_digest(CaDecoder *d, CaChunkID *ret) {
         CaDecoderNode *n;
         const void *q;
         mode_t mode;
+        int r;
 
         if (!d)
                 return -EINVAL;
         if (!ret)
                 return -EINVAL;
 
-        if (!d->payload_digest)
+        if (!d->want_payload_digest)
                 return -ENOMEDIUM;
         if (d->state != CA_DECODER_FINALIZE)
                 return -EBUSY;
@@ -5085,6 +5114,10 @@ int ca_decoder_get_payload_digest(CaDecoder *d, CaChunkID *ret) {
         if (!S_ISREG(mode) && !S_ISBLK(mode))
                 return -ENOTTY;
 
+        r = ca_digest_ensure_allocated(&d->payload_digest, ca_feature_flags_to_digest_type(d->feature_flags));
+        if (r < 0)
+                return r;
+
         q = ca_digest_read(d->payload_digest);
         if (!q)
                 return -EIO;
@@ -5098,13 +5131,14 @@ int ca_decoder_get_hardlink_digest(CaDecoder *d, CaChunkID *ret) {
         CaDecoderNode *n;
         const void *q;
         mode_t mode;
+        int r;
 
         if (!d)
                 return -EINVAL;
         if (!ret)
                 return -EINVAL;
 
-        if (!d->hardlink_digest)
+        if (!d->want_hardlink_digest)
                 return -ENOMEDIUM;
         if (d->state != CA_DECODER_FINALIZE)
                 return -EBUSY;
@@ -5119,6 +5153,10 @@ int ca_decoder_get_hardlink_digest(CaDecoder *d, CaChunkID *ret) {
                 return -ENODATA;
         if (S_ISDIR(mode))
                 return -EISDIR;
+
+        r = ca_digest_ensure_allocated(&d->hardlink_digest, ca_feature_flags_to_digest_type(d->feature_flags));
+        if (r < 0)
+                return r;
 
         q = ca_digest_read(d->hardlink_digest);
         if (!q)

--- a/src/cadecoder.h
+++ b/src/cadecoder.h
@@ -36,6 +36,9 @@ CaDecoder *ca_decoder_unref(CaDecoder *d);
 /* The actual feature flags in effect if known */
 int ca_decoder_get_feature_flags(CaDecoder *d, uint64_t *ret);
 
+/* The feature flags to expect. When the actual feature flags don't match this, this is considered an error */
+int ca_decoder_set_expected_feature_flags(CaDecoder *d, uint64_t flags);
+
 /* Various booleans to configure the mode of operation */
 int ca_decoder_set_punch_holes(CaDecoder *d, bool enabled);
 int ca_decoder_set_reflink(CaDecoder *d, bool enabled);

--- a/src/cadigest.c
+++ b/src/cadigest.c
@@ -56,7 +56,6 @@ int ca_digest_new(CaDigestType t, CaDigest **ret) {
         if (!ret)
                 return -EINVAL;
 
-
         d = new0(CaDigest, 1);
         if (!d)
                 return -ENOMEM;
@@ -180,24 +179,31 @@ CaDigestType ca_digest_type_from_string(const char *name) {
         return _CA_DIGEST_TYPE_INVALID;
 }
 
-int ca_digest_allocate_set(CaDigest **d, CaDigestType t, bool b) {
+int ca_digest_ensure_allocated(CaDigest **d, CaDigestType t) {
         int r;
 
         if (!d)
                 return -EINVAL;
-
-        if (b) {
-                if (*d)
-                        return 1;
-
-                r = ca_digest_new(t, d);
-                if (r < 0)
-                        return r;
-
-                return 1;
-        } else {
-                *d = ca_digest_free(*d);
-
+        if (*d)
                 return 0;
-        }
+
+        r = ca_digest_new(t, d);
+        if (r < 0)
+                return r;
+
+        return 1;
+}
+
+int ca_digest_set_type(CaDigest *d, CaDigestType t) {
+        if (!d)
+                return -EINVAL;
+        if (t < 0)
+                return -EINVAL;
+        if (t >= _CA_DIGEST_TYPE_MAX)
+                return -EOPNOTSUPP;
+
+        d->type = t;
+        ca_digest_reset(d);
+
+        return 0;
 }

--- a/src/cadigest.h
+++ b/src/cadigest.h
@@ -16,7 +16,7 @@ typedef enum CaDigestType {
 int ca_digest_new(CaDigestType t, CaDigest **ret);
 CaDigest *ca_digest_free(CaDigest *d);
 
-int ca_digest_allocate_set(CaDigest **d, CaDigestType t, bool b);
+int ca_digest_ensure_allocated(CaDigest **d, CaDigestType t);
 
 void ca_digest_write(CaDigest *d, const void *p, size_t l);
 
@@ -32,5 +32,7 @@ size_t ca_digest_type_size(CaDigestType t);
 
 const char *ca_digest_type_to_string(CaDigestType t);
 CaDigestType ca_digest_type_from_string(const char *name);
+
+int ca_digest_set_type(CaDigest *d, CaDigestType t);
 
 #endif

--- a/src/caformat-util.c
+++ b/src/caformat-util.c
@@ -145,7 +145,7 @@ int ca_with_feature_flags_format(uint64_t features, char **ret) {
                 features &= ~f;
         }
 
-        if ((features & ~(CA_FORMAT_EXCLUDE_NODUMP|CA_FORMAT_EXCLUDE_SUBMOUNTS)) != 0) {
+        if ((features & ~(CA_FORMAT_EXCLUDE_NODUMP|CA_FORMAT_EXCLUDE_SUBMOUNTS|CA_FORMAT_SHA512_256)) != 0) {
                 free(s);
                 return -EINVAL;
         }
@@ -464,4 +464,27 @@ uint64_t ca_feature_flags_from_magic(statfs_f_type_t magic) {
                         CA_FORMAT_WITH_FIFOS|
                         CA_FORMAT_WITH_SOCKETS;
         }
+}
+
+uint64_t ca_feature_flags_from_digest_type(CaDigestType type) {
+
+        switch (type) {
+
+        case CA_DIGEST_SHA256:
+                return 0;
+
+        case CA_DIGEST_SHA512_256:
+                return CA_FORMAT_SHA512_256;
+
+        default:
+                return UINT64_MAX;
+        }
+}
+
+CaDigestType ca_feature_flags_to_digest_type(uint64_t flags) {
+
+        if (flags & CA_FORMAT_SHA512_256)
+                return CA_DIGEST_SHA512_256;
+        else
+                return CA_DIGEST_SHA256;
 }

--- a/src/caformat-util.h
+++ b/src/caformat-util.h
@@ -3,6 +3,7 @@
 
 #include <inttypes.h>
 
+#include "cadigest.h"
 #include "util.h"
 
 const char *ca_format_type_name(uint64_t u);
@@ -22,5 +23,8 @@ uint32_t ca_feature_flags_to_fat_attrs(uint64_t flags);
 uint64_t ca_feature_flags_from_magic(statfs_f_type_t type);
 
 int ca_feature_flags_are_normalized(uint64_t f);
+
+uint64_t ca_feature_flags_from_digest_type(CaDigestType type);
+CaDigestType ca_feature_flags_to_digest_type(uint64_t flags);
 
 #endif

--- a/src/caformat.h
+++ b/src/caformat.h
@@ -116,6 +116,7 @@ enum {
         /* CA_FORMAT_WITH_SELINUX           = 0x40000000, */
         CA_FORMAT_WITH_FCAPS             = 0x80000000,
 
+        CA_FORMAT_SHA512_256             = UINT64_C(0x2000000000000000),
         CA_FORMAT_EXCLUDE_SUBMOUNTS      = UINT64_C(0x4000000000000000),
         CA_FORMAT_EXCLUDE_NODUMP         = UINT64_C(0x8000000000000000),
 
@@ -210,7 +211,16 @@ enum {
                 CA_FORMAT_WITH_CHATTR|
                 CA_FORMAT_WITH_XATTRS,
 
-        CA_FORMAT_FEATURE_FLAGS_MAX        = 0xFFFFFFFF | CA_FORMAT_EXCLUDE_NODUMP | CA_FORMAT_EXCLUDE_SUBMOUNTS,
+        CA_FORMAT_DEFAULT = /* The default set of flags */
+                CA_FORMAT_WITH_BEST|
+                CA_FORMAT_EXCLUDE_NODUMP|
+                CA_FORMAT_SHA512_256,
+
+        CA_FORMAT_FEATURE_FLAGS_MAX = /* All known bits turned on */
+                UINT64_C(0xFFFFFFFF)|
+                CA_FORMAT_EXCLUDE_NODUMP|
+                CA_FORMAT_EXCLUDE_SUBMOUNTS|
+                CA_FORMAT_SHA512_256,
 };
 
 typedef struct CaFormatHeader {

--- a/src/caremote.h
+++ b/src/caremote.h
@@ -33,6 +33,9 @@ int ca_remote_add_local_feature_flags(CaRemote *rr, uint64_t flags);
 int ca_remote_get_local_feature_flags(CaRemote *rr, uint64_t* flags);
 int ca_remote_get_remote_feature_flags(CaRemote *rr, uint64_t* flags);
 
+int ca_remote_set_digest_type(CaRemote *rr, CaDigestType type);
+int ca_remote_get_digest_type(CaRemote *rr, CaDigestType *ret);
+
 int ca_remote_set_rate_limit_bps(CaRemote *rr, uint64_t rate_limit_bps);
 
 int ca_remote_set_io_fds(CaRemote *rr, int input_fd, int output_fd);

--- a/src/casync.c
+++ b/src/casync.c
@@ -138,9 +138,6 @@ static CaSync *ca_sync_new(void) {
         s->delete = true;
         s->payload = true;
 
-        if (ca_digest_new(CA_DIGEST_SHA256, &s->chunk_digest) < 0)
-                return mfree(s);
-
         return s;
 }
 
@@ -152,7 +149,7 @@ CaSync *ca_sync_new_encode(void) {
                 return NULL;
 
         s->direction = CA_SYNC_ENCODE;
-        assert_se(ca_feature_flags_normalize(CA_FORMAT_WITH_BEST|CA_FORMAT_EXCLUDE_NODUMP, &s->feature_flags) >= 0);
+        assert_se(ca_feature_flags_normalize(CA_FORMAT_DEFAULT, &s->feature_flags) >= 0);
 
         return s;
 }
@@ -2393,18 +2390,81 @@ static int ca_sync_remote_step(CaSync *s) {
         return CA_SYNC_POLL;
 }
 
-static int ca_sync_propagate_index_flags(CaSync *s) {
-        size_t cmin, cavg, cmax;
-        uint64_t flags;
+static int ca_sync_propagate_flags_to_seeds(CaSync *s, uint64_t flags, size_t cmin, size_t cavg, size_t cmax) {
         size_t i;
         int r;
 
         assert(s);
 
-        /* If we read the header of the index file, make sure to propagate the flags and chunk size stored in it to the
-         * seeds. */
+        for (i = 0; i < s->n_seeds; i++) {
 
-        if (!ca_sync_shall_seed(s))
+                r = ca_seed_set_feature_flags(s->seeds[i], flags);
+                if (r < 0)
+                        return r;
+
+                r = ca_seed_set_chunk_size_min(s->seeds[i], cmin);
+                if (r < 0)
+                        return r;
+
+                r = ca_seed_set_chunk_size_avg(s->seeds[i], cavg);
+                if (r < 0)
+                        return r;
+
+                r = ca_seed_set_chunk_size_max(s->seeds[i], cmax);
+                if (r < 0)
+                        return r;
+        }
+
+        return 0;
+}
+
+static int ca_sync_propagate_flags_to_remotes(CaSync *s, uint64_t flags) {
+        CaDigestType dtype;
+        size_t i;
+        int r;
+
+        dtype = ca_feature_flags_to_digest_type(flags);
+        if (dtype < 0)
+                return -EINVAL;
+
+        if (s->remote_archive) {
+                r = ca_remote_set_digest_type(s->remote_archive, dtype);
+                if (r < 0)
+                        return r;
+        }
+
+        if (s->remote_index) {
+                r = ca_remote_set_digest_type(s->remote_index, dtype);
+                if (r < 0)
+                        return r;
+        }
+
+        if (s->remote_wstore) {
+                r = ca_remote_set_digest_type(s->remote_wstore, dtype);
+                if (r < 0)
+                        return r;
+        }
+
+        for (i = 0; i < s->n_remote_rstores; i++) {
+                r = ca_remote_set_digest_type(s->remote_rstores[i], dtype);
+                if (r < 0)
+                        return r;
+        }
+
+        return 0;
+}
+
+static int ca_sync_propagate_index_flags(CaSync *s) {
+        size_t cmin, cavg, cmax;
+        uint64_t flags;
+        int r;
+
+        assert(s);
+
+        /* If we read the header of the index file, make sure to propagate the flags and chunk size stored in it to the
+         * seeds and remotes. */
+
+        if (!ca_sync_shall_seed(s) && ca_sync_n_remotes(s) == 0)
                 return CA_SYNC_POLL;
 
         if (!s->index || s->index_flags_propagated) /* The flags/chunk size is already propagated */
@@ -2426,24 +2486,13 @@ static int ca_sync_propagate_index_flags(CaSync *s) {
         if (r < 0)
                 return r;
 
-        for (i = 0; i < s->n_seeds; i++) {
+        r = ca_sync_propagate_flags_to_seeds(s, flags, cmin, cavg, cmax);
+        if (r < 0)
+                return r;
 
-                r = ca_seed_set_feature_flags(s->seeds[i], flags);
-                if (r < 0)
-                        return r;
-
-                r = ca_seed_set_chunk_size_min(s->seeds[i], cmin);
-                if (r < 0)
-                        return r;
-
-                r = ca_seed_set_chunk_size_avg(s->seeds[i], cavg);
-                if (r < 0)
-                        return r;
-
-                r = ca_seed_set_chunk_size_max(s->seeds[i], cmax);
-                if (r < 0)
-                        return r;
-        }
+        r = ca_sync_propagate_flags_to_remotes(s, flags);
+        if (r < 0)
+                return r;
 
         s->index_flags_propagated = true;
         return CA_SYNC_STEP;
@@ -2683,12 +2732,20 @@ int ca_sync_has_local(CaSync *s, const CaChunkID *chunk_id) {
 }
 
 int ca_sync_make_chunk_id(CaSync *s, const void *p, size_t l, CaChunkID *ret) {
+        int r;
+
         if (!s)
                 return -EINVAL;
         if (!p && l > 0)
                 return -EINVAL;
         if (!ret)
                 return -EINVAL;
+
+        if (!s->chunk_digest) {
+                r = ca_digest_new(ca_feature_flags_to_digest_type(s->feature_flags), &s->chunk_digest);
+                if (r < 0)
+                        return r;
+        }
 
         return ca_chunk_id_make(s->chunk_digest, p, l, ret);
 }

--- a/test/http-server.py
+++ b/test/http-server.py
@@ -6,6 +6,9 @@ import http.server, socketserver, os, sys, socket, time
 
 os.chdir(sys.argv[1])
 
+if len(sys.argv) >= 3:
+    PORT = int(sys.argv[2])
+
 def send_notify(text):
 
     if text is None or text == "":

--- a/test/test-caencoder.c
+++ b/test/test-caencoder.c
@@ -30,7 +30,7 @@ static int encode(int dfd, int fd) {
         if (r < 0)
                 goto finish;
 
-        flags = CA_FORMAT_WITH_BEST|CA_FORMAT_EXCLUDE_NODUMP;
+        flags = CA_FORMAT_DEFAULT;
 
         if (geteuid() != 0)
                 flags &= ~CA_FORMAT_WITH_PRIVILEGED;

--- a/test/test-calc-digest.c
+++ b/test/test-calc-digest.c
@@ -1,0 +1,93 @@
+#include <stdio.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#include <inttypes.h>
+
+#include "cadigest.h"
+#include "util.h"
+
+int main(int argc, char *argv[]) {
+        CaDigest *digest = NULL;
+        CaDigestType type;
+        int fd = -1, r;
+        const char *q, *path, *dt;
+        size_t l;
+        char *p = NULL;
+
+        if (argc > 3) {
+                fprintf(stderr, "Expected a two arguments: digest and file name.\n");
+                r = -EINVAL;
+                goto finish;
+        }
+
+        path = argc == 3 ? argv[2] : NULL;
+        dt = argc >= 2 ? argv[1] : NULL;
+
+        if (dt) {
+                type = ca_digest_type_from_string(dt);
+                if (type < 0) {
+                        fprintf(stderr, "Failed to parse digest name: %s\n", dt);
+                        r = -EINVAL;
+                        goto finish;
+                }
+        } else
+                type = CA_DIGEST_SHA512_256;
+
+        r = ca_digest_new(type, &digest);
+        if (r < 0) {
+                fprintf(stderr, "Failed to set up digest %s: %s\n", dt, strerror(-r));
+                goto finish;
+        }
+
+        if (path) {
+                fd = open(path, O_RDONLY|O_CLOEXEC|O_NOCTTY);
+                if (fd < 0) {
+                        r = -errno;
+                        fprintf(stderr, "Failed to open %s: %s\n", path, strerror(-r));
+                        goto finish;
+                }
+        } else
+                fd = STDIN_FILENO;
+
+        for (;;) {
+                uint8_t buffer[64*1024];
+                ssize_t n;
+
+                n = read(fd, buffer, sizeof(buffer));
+                if (n < 0) {
+                        r = -errno;
+                        fprintf(stderr, "Failed to read: %s\n", strerror(-r));
+                        goto finish;
+                }
+                if (n == 0) /* EOF */
+                        break;
+
+                ca_digest_write(digest, buffer, (size_t) n);
+        }
+
+        q = ca_digest_read(digest);
+        l = ca_digest_get_size(digest);
+
+        p = hexmem(q, l);
+        if (!p) {
+                r = log_oom();
+                goto finish;
+        }
+
+        fputs(p, stdout);
+        fputc('\n', stdout);
+
+        r = 0;
+
+finish:
+        ca_digest_free(digest);
+
+        if (fd > 2)
+                safe_close(fd);
+
+        free(p);
+
+        return r < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/test/test-casync.c
+++ b/test/test-casync.c
@@ -25,7 +25,7 @@ int main(int argc, char *argv[]) {
 
         assert_se(s = ca_sync_new_encode());
 
-        flags = CA_FORMAT_WITH_BEST|CA_FORMAT_EXCLUDE_NODUMP;
+        flags = CA_FORMAT_DEFAULT;
 
         if (geteuid() != 0)
                 flags &= ~CA_FORMAT_WITH_PRIVILEGED;

--- a/test/test-nbd.sh.in
+++ b/test/test-nbd.sh.in
@@ -1,6 +1,12 @@
 #!/bin/bash -ex
 
-PARAMS=-v
+if [ -z "$1" ] ; then
+    DIGEST=sha512-256
+else
+    DIGEST="$1"
+fi
+
+PARAMS="-v --digest=$DIGEST"
 
 CASYNC_PROTOCOL_PATH=@top_builddir@
 export CASYNC_PROTOCOL_PATH
@@ -11,7 +17,7 @@ mkdir -p $SCRATCH_DIR
 dd if=/dev/urandom of=$SCRATCH_DIR/blob bs=102400 count=80
 
 @top_builddir@/casync $PARAMS digest $SCRATCH_DIR/blob > $SCRATCH_DIR/test.digest
-sha256sum $SCRATCH_DIR/blob | cut -c -64 > $SCRATCH_DIR/test.digest2
+@top_builddir@/test-calc-digest $DIGEST $SCRATCH_DIR/blob > $SCRATCH_DIR/test.digest2
 
 @top_builddir@/casync $PARAMS make $SCRATCH_DIR/test.caibx $SCRATCH_DIR/blob
 @top_builddir@/casync $PARAMS digest $SCRATCH_DIR/test.caibx > $SCRATCH_DIR/test.caibx.digest
@@ -22,8 +28,8 @@ diff -q $SCRATCH_DIR/test.digest $SCRATCH_DIR/test.caibx.digest
 @top_builddir@/casync $PARAMS extract $SCRATCH_DIR/test.caibx $SCRATCH_DIR/blob2
 @top_builddir@/casync $PARAMS extract $SCRATCH_DIR/test.caibx --seed=$SCRATCH_DIR/blob2 $SCRATCH_DIR/blob3
 
-sha256sum $SCRATCH_DIR/blob2 | cut -c -64 > $SCRATCH_DIR/extract.digest
-sha256sum $SCRATCH_DIR/blob3 | cut -c -64 > $SCRATCH_DIR/extract2.digest
+@top_builddir@/test-calc-digest $DIGEST $SCRATCH_DIR/blob2 > $SCRATCH_DIR/extract.digest
+@top_builddir@/test-calc-digest $DIGEST $SCRATCH_DIR/blob3 > $SCRATCH_DIR/extract2.digest
 
 diff -q $SCRATCH_DIR/test.digest $SCRATCH_DIR/extract.digest
 diff -q $SCRATCH_DIR/test.digest $SCRATCH_DIR/extract2.digest
@@ -34,7 +40,7 @@ if [ `id -u` == 0 ] ; then
     if test -e /dev/nbd0 ; then
         MKDEV_PID=`@top_builddir@/notify-wait @top_builddir@/casync $PARAMS mkdev $SCRATCH_DIR/test.caibx $SCRATCH_DIR/test-node`
 
-        dd if=$SCRATCH_DIR/test-node bs=102400 count=80 | sha256sum | cut -c -64 > $SCRATCH_DIR/mkdev.digest
+        dd if=$SCRATCH_DIR/test-node bs=102400 count=80 | @top_builddir@/test-calc-digest $DIGEST > $SCRATCH_DIR/mkdev.digest
 
         diff -q $SCRATCH_DIR/test.digest $SCRATCH_DIR/mkdev.digest
 

--- a/test/test-script-sha256.sh.in
+++ b/test/test-script-sha256.sh.in
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+
+# This is the same as test-script.sh, except that we force the digest to be
+# sha256, in order to detect potential incompatibilities with the remoting
+# feature.
+
+exec @top_builddir@/test-script.sh sha256

--- a/test/test-script.sh.in
+++ b/test/test-script.sh.in
@@ -171,18 +171,20 @@ diff -q $SCRATCH_DIR/test.digest $SCRATCH_DIR/test2.catar.digest
 
 ### Test HTTP Remoting
 
+HTTP_PORT=$((10000 + $$ % 10000))
+
 CASYNC_PROTOCOL_PATH=@top_builddir@
 export CASYNC_PROTOCOL_PATH
 
-HTTP_PID=`@top_builddir@/notify-wait  @top_srcdir@/test/http-server.py $SCRATCH_DIR`
+HTTP_PID=`@top_builddir@/notify-wait  @top_srcdir@/test/http-server.py $SCRATCH_DIR $HTTP_PORT`
 
-@top_builddir@/casync $PARAMS list http://localhost:4321/test2.caidx > $SCRATCH_DIR/test3.caidx.list
-@top_builddir@/casync $PARAMS mtree http://localhost:4321/test2.caidx > $SCRATCH_DIR/test3.caidx.mtree
-@top_builddir@/casync $PARAMS digest http://localhost:4321/test2.caidx > $SCRATCH_DIR/test3.caidx.digest
+@top_builddir@/casync $PARAMS list http://localhost:$HTTP_PORT/test2.caidx > $SCRATCH_DIR/test3.caidx.list
+@top_builddir@/casync $PARAMS mtree http://localhost:$HTTP_PORT/test2.caidx > $SCRATCH_DIR/test3.caidx.mtree
+@top_builddir@/casync $PARAMS digest http://localhost:$HTTP_PORT/test2.caidx > $SCRATCH_DIR/test3.caidx.digest
 
-@top_builddir@/casync $PARAMS list http://localhost:4321/test2.catar > $SCRATCH_DIR/test3.catar.list
-@top_builddir@/casync $PARAMS mtree http://localhost:4321/test2.catar > $SCRATCH_DIR/test3.catar.mtree
-@top_builddir@/casync $PARAMS digest http://localhost:4321/test2.catar > $SCRATCH_DIR/test3.catar.digest
+@top_builddir@/casync $PARAMS list http://localhost:$HTTP_PORT/test2.catar > $SCRATCH_DIR/test3.catar.list
+@top_builddir@/casync $PARAMS mtree http://localhost:$HTTP_PORT/test2.catar > $SCRATCH_DIR/test3.catar.mtree
+@top_builddir@/casync $PARAMS digest http://localhost:$HTTP_PORT/test2.catar > $SCRATCH_DIR/test3.catar.digest
 
 diff -q $SCRATCH_DIR/test.list $SCRATCH_DIR/test3.caidx.list
 diff -q $SCRATCH_DIR/test.mtree $SCRATCH_DIR/test3.caidx.mtree

--- a/test/test-script.sh.in
+++ b/test/test-script.sh.in
@@ -1,9 +1,15 @@
 #!/bin/bash -ex
 
-if [ `id -u` == 0 ] ; then
-    PARAMS="-v"
+if [ -z "$1" ] ; then
+    DIGEST=sha512-256
 else
-    PARAMS="-v --without=privileged"
+    DIGEST="$1"
+fi
+
+if [ `id -u` == 0 ] ; then
+    PARAMS="-v --digest=$DIGEST"
+else
+    PARAMS="-v --without=privileged --digest=$DIGEST"
 fi
 
 CASYNC_PROTOCOL_PATH=@top_builddir@
@@ -29,7 +35,7 @@ cd $SCRATCH_DIR/src
 @top_builddir@/casync $PARAMS list $SCRATCH_DIR/test.catar > $SCRATCH_DIR/test.catar.list
 @top_builddir@/casync $PARAMS mtree $SCRATCH_DIR/test.catar > $SCRATCH_DIR/test.catar.mtree
 @top_builddir@/casync $PARAMS digest $SCRATCH_DIR/test.catar > $SCRATCH_DIR/test.catar.digest
-sha256sum $SCRATCH_DIR/test.catar | cut -c -64 > $SCRATCH_DIR/test.catar.digest2
+@top_builddir@/test-calc-digest $DIGEST $SCRATCH_DIR/test.catar > $SCRATCH_DIR/test.catar.digest2
 
 @top_builddir@/casync $PARAMS make $SCRATCH_DIR/test.caidx
 @top_builddir@/casync $PARAMS list $SCRATCH_DIR/test.caidx > $SCRATCH_DIR/test.caidx.list


### PR DESCRIPTION
sha256 remains supported, via --digest=sha256, as it has benefits when
focussing on 32bit systems, but the new default is sha512/256, as it is
substantially faster on 64bit systems.

The used hash algorithm is encoded in the feature flags field in the
index and archive files, so that directing casync onto index or archive
files is enough for it to determine how to encode/look for chunks.