### PR TITLE
Define __NR_renameat2 for multiple architectures

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -480,6 +480,8 @@ static inline bool strv_isempty(char **l) {
 #  ifndef __NR_renameat2
 #    if defined __x86_64__
 #      define __NR_renameat2 316
+#    elif defined __alpha__
+#      define __NR_renameat2 510
 #    elif defined __arm__
 #      define __NR_renameat2 382
 #    elif defined __aarch64__

--- a/src/util.h
+++ b/src/util.h
@@ -488,6 +488,8 @@ static inline bool strv_isempty(char **l) {
 #      define __NR_renameat2 276
 #    elif defined __hppa__
 #      define __NR_renameat2 337
+#    elif defined __ia64__
+#      define __NR_renameat2 1338
 #    elif defined _MIPS_SIM
 #      if _MIPS_SIM == _MIPS_SIM_ABI32
 #        define __NR_renameat2 4351

--- a/src/util.h
+++ b/src/util.h
@@ -512,6 +512,8 @@ static inline bool strv_isempty(char **l) {
 #      define __NR_renameat2 371
 #    elif defined __sh64__
 #      define __NR_renameat2 382
+#    elif defined __sparc__
+#      define __NR_renameat2 345
 #    elif defined __arc__
 #      define __NR_renameat2 276
 #    else

--- a/src/util.h
+++ b/src/util.h
@@ -508,6 +508,8 @@ static inline bool strv_isempty(char **l) {
 #      define __NR_renameat2 357
 #    elif defined __s390__ || defined __s390x__
 #      define __NR_renameat2 347
+#    elif defined __sh__
+#      define __NR_renameat2 371
 #    elif defined __arc__
 #      define __NR_renameat2 276
 #    else

--- a/src/util.h
+++ b/src/util.h
@@ -510,6 +510,8 @@ static inline bool strv_isempty(char **l) {
 #      define __NR_renameat2 347
 #    elif defined __sh__
 #      define __NR_renameat2 371
+#    elif defined __sh64__
+#      define __NR_renameat2 382
 #    elif defined __arc__
 #      define __NR_renameat2 276
 #    else

--- a/src/util.h
+++ b/src/util.h
@@ -486,6 +486,8 @@ static inline bool strv_isempty(char **l) {
 #      define __NR_renameat2 382
 #    elif defined __aarch64__
 #      define __NR_renameat2 276
+#    elif defined __hppa__
+#      define __NR_renameat2 337
 #    elif defined _MIPS_SIM
 #      if _MIPS_SIM == _MIPS_SIM_ABI32
 #        define __NR_renameat2 4351

--- a/src/util.h
+++ b/src/util.h
@@ -490,6 +490,8 @@ static inline bool strv_isempty(char **l) {
 #      define __NR_renameat2 337
 #    elif defined __ia64__
 #      define __NR_renameat2 1338
+#    elif defined __m68k__
+#      define __NR_renameat2 351
 #    elif defined _MIPS_SIM
 #      if _MIPS_SIM == _MIPS_SIM_ABI32
 #        define __NR_renameat2 4351

--- a/src/util.h
+++ b/src/util.h
@@ -504,7 +504,7 @@ static inline bool strv_isempty(char **l) {
 #      endif
 #    elif defined __i386__
 #      define __NR_renameat2 353
-#    elif defined __powerpc64__
+#    elif defined __powerpc64__ || defined __powerpc__
 #      define __NR_renameat2 357
 #    elif defined __s390__ || defined __s390x__
 #      define __NR_renameat2 347


### PR DESCRIPTION
```casync``` was recently uploaded to Debian for the first time [1].

After the buildds finished building the packages, I noticed that the definitions for ```__NR__renameat2``` is missing for multiple architectures. This is fixed in this PR.

Adrian

> [1] https://packages.qa.debian.org/c/casync.html
> [2] https://buildd.debian.org/status/package.php?p=casync&suite=sid