### PR TITLE
Bump test timeouts to 3 minutes.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -280,7 +280,7 @@ foreach test_name : test_sources + non_test_sources
 
         if test_sources.contains(test_name)
                 test(test_name, exe,
-                     timeout : 2 * 60)
+                     timeout : 3 * 60)
         endif
 endforeach
 


### PR DESCRIPTION
2 minutes is too short for slow architectures


---

Please don't merge until https://buildd.debian.org/status/package.php?p=casync is free of timeout errors, it may be that 3 is still not enough.