### PR TITLE
include sys/uio.h to get declaration of writev()

### DIFF
--- a/src/canbd.c
+++ b/src/canbd.c
@@ -9,6 +9,7 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
+#include <sys/uio.h>
 #include <sys/wait.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Closes: https://github.com/systemd/casync/issues/71
Signed-off-by: Igor Gnatenko <ignatenkobrain@fedoraproject.org>