### PR TITLE
Fix build without selinux and refuse --with=selinux when compiled without

### DIFF
--- a/src/cadecoder.c
+++ b/src/cadecoder.c
@@ -13,7 +13,7 @@
 #include <linux/msdos_fs.h>
 
 #if HAVE_SELINUX
-#include <selinux/selinux.h>
+#  include <selinux/selinux.h>
 #endif
 
 #include "cadecoder.h"

--- a/src/caremote.c
+++ b/src/caremote.c
@@ -2729,7 +2729,7 @@ int ca_remote_forget_chunk(CaRemote *rr, const CaChunkID *id) {
 
                 p = startswith(qpos, "low-priority/");
                 if (!p) {
-                        p = startswith(p, "high-priority/");
+                        p = startswith(qpos, "high-priority/");
                         if (!p) {
                                 r = -EBADMSG;
                                 goto finish;


### PR DESCRIPTION
Fixes #73.

The output is pretty crappy:

  $ build/casync --with=selinux make ...
  Failed to run synchronizer: Operation not supported

but that's being tracked as #44.