### PR TITLE
Fix seed chunker discriminator not set

### DIFF
--- a/src/caseed.c
+++ b/src/caseed.c
@@ -773,39 +773,12 @@ int ca_seed_set_feature_flags(CaSeed *s, uint64_t flags) {
         return ca_feature_flags_normalize(flags, &s->feature_flags);
 }
 
-int ca_seed_set_chunk_size_min(CaSeed *s, size_t cmin) {
+int ca_seed_set_chunk_size(CaSeed *s, size_t cmin, size_t cavg, size_t cmax) {
         if (!s)
                 return -EINVAL;
-        if (cmin < CA_CHUNK_SIZE_LIMIT_MIN)
-                return -EINVAL;
-        if (cmin > CA_CHUNK_SIZE_LIMIT_MAX)
-                return -EINVAL;
 
-        s->chunker.chunk_size_min = cmin;
-        return 0;
-}
+        ca_chunker_set_size(&s->chunker, cmin, cavg, cmax);
 
-int ca_seed_set_chunk_size_avg(CaSeed *s, size_t cavg) {
-        if (!s)
-                return -EINVAL;
-        if (cavg < CA_CHUNK_SIZE_LIMIT_MIN)
-                return -EINVAL;
-        if (cavg > CA_CHUNK_SIZE_LIMIT_MAX)
-                return -EINVAL;
-
-        s->chunker.chunk_size_avg = cavg;
-        return 0;
-}
-
-int ca_seed_set_chunk_size_max(CaSeed *s, size_t cmax) {
-        if (!s)
-                return -EINVAL;
-        if (cmax < CA_CHUNK_SIZE_LIMIT_MIN)
-                return -EINVAL;
-        if (cmax > CA_CHUNK_SIZE_LIMIT_MAX)
-                return -EINVAL;
-
-        s->chunker.chunk_size_max = cmax;
         return 0;
 }
 

--- a/src/caseed.h
+++ b/src/caseed.h
@@ -36,9 +36,7 @@ int ca_seed_current_mode(CaSeed *seed, mode_t *ret);
 
 int ca_seed_set_feature_flags(CaSeed *s, uint64_t flags);
 
-int ca_seed_set_chunk_size_min(CaSeed *s, size_t cmin);
-int ca_seed_set_chunk_size_avg(CaSeed *s, size_t cavg);
-int ca_seed_set_chunk_size_max(CaSeed *s, size_t cmax);
+int ca_seed_set_chunk_size(CaSeed *s, size_t cmin, size_t cavg, size_t cmax);
 
 int ca_seed_set_hardlink(CaSeed *s, bool b);
 int ca_seed_set_chunks(CaSeed *s, bool b);

--- a/src/casync.c
+++ b/src/casync.c
@@ -2473,15 +2473,7 @@ static int ca_sync_propagate_flags_to_seeds(CaSync *s, uint64_t flags, size_t cm
                 if (r < 0)
                         return r;
 
-                r = ca_seed_set_chunk_size_min(s->seeds[i], cmin);
-                if (r < 0)
-                        return r;
-
-                r = ca_seed_set_chunk_size_avg(s->seeds[i], cavg);
-                if (r < 0)
-                        return r;
-
-                r = ca_seed_set_chunk_size_max(s->seeds[i], cmax);
+                r = ca_seed_set_chunk_size(s->seeds[i], cmin, cavg, cmax);
                 if (r < 0)
                         return r;
         }


### PR DESCRIPTION
When user set a chunk_size, chunker.discriminator should be re-caculated
with new chunk_size. Elsewise, Local seed cache can't be used to extract
remote server.