### PR TITLE
cafuse: do not return from iterate_until_file() in CA_SYNC_POLL case

### DIFF
--- a/src/cafuse.c
+++ b/src/cafuse.c
@@ -64,7 +64,7 @@ static int iterate_until_file(CaSync *s) {
                                 return r;
                         }
 
-                        return 0;
+                        break;
 
                 case CA_SYNC_NOT_FOUND:
                         /* fprintf(stderr, "Not found.\n"); */


### PR DESCRIPTION
CA_SYNC_POLL indicates that more data needs to be received. This will
occur for example, when the read() call in ca_remote_read() returns
EAGAIN.
Returning 0 from iterate_until_file() instead indicates that reading
file data was completed, successfully. Returning this in case of
CA_SYNC_POLL will result in file data not being initialized correctly.

In case of a getattr() fuse call, for example, casync will always return
a directory entry for the first call, no matter if the requested entry
exists or not.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>