### PR TITLE
mkosi: add missing build dependencies

### DIFF
--- a/mkosi.default
+++ b/mkosi.default
@@ -16,8 +16,10 @@ BuildPackages=
         gcc
         libacl-devel
         libcurl-devel
+        libzstd-devel
         openssl-devel
         meson
+        /usr/bin/sphinx-build
         pkgconfig
         rsync
         xz-devel


### PR DESCRIPTION
Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>