### PR TITLE
src: cadecoder: remove origin size sanity check in ca_decoder_put_data()

### DIFF
--- a/src/cadecoder.c
+++ b/src/cadecoder.c
@@ -4400,9 +4400,6 @@ int ca_decoder_put_data(CaDecoder *d, const void *p, size_t size, CaOrigin *orig
         if (d->eof)
                 return -EBUSY;
 
-        if (origin && origin->n_bytes != size)
-                return -EINVAL;
-
         if (size == 0)
                 return 0;
 


### PR DESCRIPTION
When mounting a casync .caidx describing a directory that contains a file
system image while using the block device `/dev/mmcblk0p1` as seed, casync
fails when accessing this image:

> casync mount http://127.0.0.1:8080/packed-directory.caidx --seed=/dev/mmcblk0p1 /mnt/test

> user@device:~# md5sum /mnt/test/rootfs-image.ext4
> md5sum: can't read '/mnt/test/rootfs-image.ext4': Invalid argument

The trigger for this error is a sanity check in `ca_decoder_put_data()`:

    if (origin && origin->n_bytes != size)
          return -EINVAL;

It checks that the methods `size` argument equals the `n_bytes` member of
`CaOrigin` argument `origin` if provided.

This check is triggered in method `ca_sync_process_decoder_request()` when
`ca_sync_get()` returns data received from `ca_sync_get_local()` and thus has
an `origin` set where `origin->n_bytes` equals the `chunk_size`.
If then `s->chunk_skip` is set to a value > 0, the `chunk_size` passed to
`ca_decoder_put_data()` as `size` argument will be decreased by the value of
`s->chunk_skip`.
Following this path, the values `origin->n_bytes` and `size` cannot be equal
anymore and the check *must* fail.

Simply removing the sanity check lets the scenario described above gracefully
perform its expected behavior.