### PR TITLE
meson.build: minimum required version for zstd

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -107,7 +107,8 @@ openssl = dependency('openssl',
 
 libz = dependency('zlib')
 
-libzstd = dependency('libzstd')
+libzstd = dependency('libzstd',
+                      version : '>= 0.8.1')
 
 libacl = cc.find_library('acl')
 


### PR DESCRIPTION
struct ZSTD_CStream was introduced in version 0.8.1.  Prefer failure
during configure stage instead of compilation if a too old version of
zstd is installed.

Signed-off-by: Gunnar Andersson <gandersson@genivi.org>