### PR TITLE
build: Specify install directories in terms of libdir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -93,9 +93,10 @@ endif
 
 prefixdir = get_option('prefix')
 bindir = join_paths(prefixdir, get_option('bindir'))
+libexecdir = join_paths(prefixdir, get_option('libexecdir'))
 datadir = join_paths(prefixdir, get_option('datadir'))
 docdir = join_paths(datadir, 'doc/casync')
-protocoldir = join_paths(prefixdir, 'lib/casync/protocols')
+protocoldir = join_paths(libexecdir, 'casync/protocols')
 conf.set_quoted('CASYNC_PROTOCOL_PATH', protocoldir)
 
 liblzma = dependency('liblzma',

--- a/meson.build
+++ b/meson.build
@@ -142,8 +142,8 @@ subdir('test')
 
 includes = include_directories('src')
 
-udevlibexecdir = join_paths(prefixdir, 'lib/udev')
-udevrulesdir = join_paths(udevlibexecdir, 'rules.d')
+udevdir = dependency('udev').get_pkgconfig_variable('udevdir')
+udevrulesdir = join_paths(udevdir, 'rules.d')
 
 subdir('doc')
 


### PR DESCRIPTION
It's consistent that way and fixes a problem when <libdir> != <prefix>/lib