### PR TITLE
caremote: Add enum for readability of caremote URL arguments

### DIFF
--- a/src/caremote.c
+++ b/src/caremote.c
@@ -1023,11 +1023,12 @@ static int ca_remote_start(CaRemote *rr) {
                                 i++;
                         }
 
-                        args[i++] = (char*) ((rr->local_feature_flags & (CA_PROTOCOL_PUSH_CHUNKS|CA_PROTOCOL_PUSH_INDEX|CA_PROTOCOL_PUSH_ARCHIVE)) ? "push" : "pull");
-                        args[i++] = /* rr->base_url ? rr->base_url + skip :*/ (char*) "-";
-                        args[i++] = rr->archive_url ? rr->archive_url + skip : (char*) "-";
-                        args[i++] = rr->index_url ? rr->index_url + skip : (char*) "-";
-                        args[i++] = rr->wstore_url ? rr->wstore_url + skip: (char*) "-";
+                        args[i + CA_REMOTE_ARG_OPERATION] = (char*) ((rr->local_feature_flags & (CA_PROTOCOL_PUSH_CHUNKS|CA_PROTOCOL_PUSH_INDEX|CA_PROTOCOL_PUSH_ARCHIVE)) ? "push" : "pull");
+                        args[i + CA_REMOTE_ARG_BASE_URL] = /* rr->base_url ? rr->base_url + skip :*/ (char*) "-";
+                        args[i + CA_REMOTE_ARG_ARCHIVE_URL] = rr->archive_url ? rr->archive_url + skip : (char*) "-";
+                        args[i + CA_REMOTE_ARG_INDEX_URL] = rr->index_url ? rr->index_url + skip : (char*) "-";
+                        args[i + CA_REMOTE_ARG_WSTORE_URL] = rr->wstore_url ? rr->wstore_url + skip: (char*) "-";
+                        i += _CA_REMOTE_ARG_MAX;
 
                         STRV_FOREACH(u, rr->rstore_urls)
                                 args[i++] = *u + skip;

--- a/src/caremote.h
+++ b/src/caremote.h
@@ -26,6 +26,15 @@ enum {
         CA_REMOTE_READ_ARCHIVE_EOF, /* pull: ARCHIVE data is now complete */
 };
 
+enum {
+        CA_REMOTE_ARG_OPERATION = 0,
+        CA_REMOTE_ARG_BASE_URL,
+        CA_REMOTE_ARG_ARCHIVE_URL,
+        CA_REMOTE_ARG_INDEX_URL,
+        CA_REMOTE_ARG_WSTORE_URL,   /* This should be last except MAX */
+        _CA_REMOTE_ARG_MAX,
+};
+
 CaRemote* ca_remote_new(void);
 CaRemote* ca_remote_ref(CaRemote *rr);
 CaRemote* ca_remote_unref(CaRemote *rr);

--- a/src/casync-http.c
+++ b/src/casync-http.c
@@ -338,19 +338,19 @@ static int run(int argc, char *argv[]) {
         long protocol_status;
         int r;
 
-        if (argc < 5) {
-                log_error("Expected at least 5 arguments.");
+        if (argc < _CA_REMOTE_ARG_MAX) {
+                log_error("Expected at least %d arguments.", _CA_REMOTE_ARG_MAX);
                 return -EINVAL;
         }
 
         /* fprintf(stderr, "base=%s archive=%s index=%s wstore=%s\n", argv[1], argv[2], argv[3], argv[4]); */
 
-        base_url = empty_or_dash_to_null(argv[1]);
-        archive_url = empty_or_dash_to_null(argv[2]);
-        index_url = empty_or_dash_to_null(argv[3]);
-        wstore_url = empty_or_dash_to_null(argv[4]);
+        base_url = empty_or_dash_to_null(argv[CA_REMOTE_ARG_BASE_URL]);
+        archive_url = empty_or_dash_to_null(argv[CA_REMOTE_ARG_ARCHIVE_URL]);
+        index_url = empty_or_dash_to_null(argv[CA_REMOTE_ARG_INDEX_URL]);
+        wstore_url = empty_or_dash_to_null(argv[CA_REMOTE_ARG_WSTORE_URL]);
 
-        n_stores = !!wstore_url + (argc - 5);
+        n_stores = !!wstore_url + (argc - _CA_REMOTE_ARG_MAX);
 
         if (base_url) {
                 log_error("Pushing/pulling to base via HTTP not yet supported.");
@@ -474,9 +474,9 @@ static int run(int argc, char *argv[]) {
 
                 current_store = current_store % n_stores;
                 if (wstore_url)
-                        store_url = current_store == 0 ? wstore_url : argv[current_store + 5 - 1];
+                        store_url = current_store == 0 ? wstore_url : argv[current_store + _CA_REMOTE_ARG_MAX - 1];
                 else
-                        store_url = argv[current_store + 5];
+                        store_url = argv[current_store + _CA_REMOTE_ARG_MAX];
                 /* current_store++; */
 
                 free(url_buffer);


### PR DESCRIPTION
Between caremote and casync-http, URL arguements are accessed by
relative offset. To readability, the offsets should be enumeration.