### PR TITLE
tree-wide: add SPDX license identifiers to files

### DIFF
--- a/doc/casync.rst
+++ b/doc/casync.rst
@@ -1,3 +1,5 @@
+.. SPDX-License-Identifier: LGPL-2.1+
+
 :orphan:
 
 casync manual page

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# SPDX-License-Identifier: LGPL-2.1+
 #
 # casync documentation build configuration file, created by
 # sphinx-quickstart on Tue Jun 20 16:46:39 2017.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,7 +1,6 @@
+.. SPDX-License-Identifier: LGPL-2.1+
 .. casync documentation master file, created by
    sphinx-quickstart on Tue Jun 20 16:46:39 2017.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
 
 Welcome to casync's documentation!
 ==================================

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
 sphinx_sources = [
         'conf.py',
         'casync.rst',

--- a/meson.build
+++ b/meson.build
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
 project('casync', 'c',
         version : '2',
         license : 'LGPLv2+',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 # -*- mode: meson -*-
+# SPDX-License-Identifier: LGPL-2.1+
 
 option('fuse', type : 'boolean', value : true,
        description : 'build the FUSE integration (requires fuse-devel)')

--- a/mkosi.build
+++ b/mkosi.build
@@ -1,4 +1,5 @@
 #!/bin/sh -ex
+# SPDX-License-Identifier: LGPL-2.1+
 
 export LC_CTYPE=C.UTF-8
 meson build

--- a/mkosi.default
+++ b/mkosi.default
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
 [Distribution]
 Distribution=fedora
 Release=26

--- a/src/75-casync.rules.in
+++ b/src/75-casync.rules.in
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
 ACTION=="remove", GOTO="casync_end"
 
 SUBSYSTEM=="block", KERNEL=="nbd*", IMPORT{program}="@bindir_unquoted@/casync udev %N"

--- a/src/cachunk.c
+++ b/src/cachunk.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>

--- a/src/cachunk.h
+++ b/src/cachunk.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocachunkhfoo
 #define foocachunkhfoo
 

--- a/src/cachunker.c
+++ b/src/cachunker.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <math.h>
 
 #include "cachunk.h"

--- a/src/cachunker.h
+++ b/src/cachunker.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foochunkerhfoo
 #define foochunkerhfoo
 

--- a/src/cachunkid.c
+++ b/src/cachunkid.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <assert.h>
 #include <errno.h>
 

--- a/src/cachunkid.h
+++ b/src/cachunkid.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocaobjectidhfoo
 #define foocaobjectidhfoo
 

--- a/src/cacommon.h
+++ b/src/cacommon.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef cacommonhfoo
 #define cacommonhfoo
 

--- a/src/cacompression.c
+++ b/src/cacompression.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include "util.h"
 #include "cacompression.h"
 

--- a/src/cacompression.h
+++ b/src/cacompression.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocacompressorhfoo
 #define foocacompressorhfoo
 

--- a/src/cadecoder.c
+++ b/src/cadecoder.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <fcntl.h>
 #include <grp.h>
 #include <pwd.h>

--- a/src/cadecoder.h
+++ b/src/cadecoder.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocadecoderhfoo
 #define foocadecoderhfoo
 

--- a/src/cadigest.c
+++ b/src/cadigest.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <openssl/sha.h>
 
 #include "cadigest.h"

--- a/src/cadigest.h
+++ b/src/cadigest.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocadigesthfoo
 #define foocadigesthfoo
 

--- a/src/caencoder.c
+++ b/src/caencoder.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <acl/libacl.h>
 #include <assert.h>
 #include <dirent.h>

--- a/src/caencoder.h
+++ b/src/caencoder.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocaencoderhfoo
 #define foocaencoderhfoo
 

--- a/src/cafileroot.c
+++ b/src/cafileroot.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include "cafileroot.h"
 #include "util.h"
 

--- a/src/cafileroot.h
+++ b/src/cafileroot.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocafileroothfoo
 #define foocafileroothfoo
 

--- a/src/caformat-util.c
+++ b/src/caformat-util.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <linux/fs.h>
 #include <linux/msdos_fs.h>
 

--- a/src/caformat-util.h
+++ b/src/caformat-util.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocaformatutilhfoo
 #define foocaformatutilhfoo
 

--- a/src/caformat.h
+++ b/src/caformat.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocaformathfoo
 #define foocaformathfoo
 

--- a/src/cafuse.c
+++ b/src/cafuse.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #define FUSE_USE_VERSION 26
 
 #include <fuse.h>

--- a/src/cafuse.h
+++ b/src/cafuse.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef cafusehfoo
 #define cafusehfoo
 

--- a/src/caindex.c
+++ b/src/caindex.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <fcntl.h>
 #include <stddef.h>
 #include <sys/stat.h>

--- a/src/caindex.h
+++ b/src/caindex.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocaindexhfoo
 #define foocaindexhfoo
 

--- a/src/calocation.c
+++ b/src/calocation.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <sys/fcntl.h>
 
 #include "calocation.h"

--- a/src/calocation.h
+++ b/src/calocation.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocalocationhfoo
 #define foocalocationhfoo
 

--- a/src/camakebst.c
+++ b/src/camakebst.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include "camakebst.h"
 #include "util.h"
 

--- a/src/camakebst.h
+++ b/src/camakebst.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocamakebsthfoo
 #define foocamakebsthfoo
 

--- a/src/canbd.c
+++ b/src/canbd.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <fcntl.h>
 #include <linux/fs.h>
 #include <linux/nbd.h>

--- a/src/canbd.h
+++ b/src/canbd.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocanbdfoo
 #define foocanbdfoo
 

--- a/src/caorigin.c
+++ b/src/caorigin.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include "caorigin.h"
 
 /* #undef EUNATCH */

--- a/src/caorigin.h
+++ b/src/caorigin.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocaoriginhfoo
 #define foocaoriginhfoo
 

--- a/src/caprotocol-util.c
+++ b/src/caprotocol-util.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include "caprotocol-util.h"
 #include "caprotocol.h"
 

--- a/src/caprotocol-util.h
+++ b/src/caprotocol-util.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <inttypes.h>
 
 #include "caprotocol.h"

--- a/src/caprotocol.h
+++ b/src/caprotocol.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocaprotocolhfoo
 #define foocaprotocolhfoo
 

--- a/src/caremote.c
+++ b/src/caremote.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <errno.h>
 #include <fcntl.h>
 #include <stddef.h>

--- a/src/caremote.h
+++ b/src/caremote.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocaremotehfoo
 #define foocaremotehfoo
 

--- a/src/caseed.c
+++ b/src/caseed.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <sys/stat.h>
 #include <fcntl.h>
 

--- a/src/caseed.h
+++ b/src/caseed.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocaseedhfoo
 #define foocaseedhfoo
 

--- a/src/castore.c
+++ b/src/castore.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <fcntl.h>
 #include <lzma.h>
 #include <sys/stat.h>

--- a/src/castore.h
+++ b/src/castore.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocastorehfoo
 #define foocastorehfoo
 

--- a/src/casync-http.c
+++ b/src/casync-http.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <curl/curl.h>
 #include <getopt.h>
 #include <stddef.h>

--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/src/casync.c
+++ b/src/casync.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <fcntl.h>
 #include <sys/poll.h>
 #include <sys/stat.h>

--- a/src/casync.h
+++ b/src/casync.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocasynchfoo
 #define foocasynchfoo
 

--- a/src/cautil.c
+++ b/src/cautil.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <assert.h>
 #include <string.h>
 #include <sys/types.h>

--- a/src/cautil.h
+++ b/src/cautil.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocautilhfoo
 #define foocautilhfoo
 

--- a/src/compressor.c
+++ b/src/compressor.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include "compressor.h"
 #include "util.h"
 

--- a/src/compressor.h
+++ b/src/compressor.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foocompresshorhfoo
 #define foocompresshorhfoo
 

--- a/src/copy.c
+++ b/src/copy.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include "copy.h"
 
 #if !HAVE_COPY_FILE_RANGE

--- a/src/def.h
+++ b/src/def.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foodefhfoo
 #define foodefhfoo
 

--- a/src/fssize.c
+++ b/src/fssize.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include "fssize.h"
 #include "util.h"
 

--- a/src/fssize.h
+++ b/src/fssize.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foofssizehfoo
 #define foofssizehfoo
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
 libshared_sources = files('''
         cachunk.c
         cachunk.h

--- a/src/notify.c
+++ b/src/notify.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <stddef.h>
 #include <sys/socket.h>
 #include <sys/un.h>

--- a/src/notify.h
+++ b/src/notify.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foonotifyhfoo
 #define foonotifyhfoo
 

--- a/src/parse-util.c
+++ b/src/parse-util.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <assert.h>
 #include <errno.h>
 #include <inttypes.h>

--- a/src/parse-util.h
+++ b/src/parse-util.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef fooparseutilfoo
 #define fooparseutilfoo
 

--- a/src/realloc-buffer.c
+++ b/src/realloc-buffer.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <assert.h>
 #include <unistd.h>
 

--- a/src/realloc-buffer.h
+++ b/src/realloc-buffer.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef fooreallocbufferhfoo
 #define fooreallocbufferhfoo
 

--- a/src/reflink.c
+++ b/src/reflink.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <fcntl.h>
 #include <linux/fs.h>
 #include <stddef.h>

--- a/src/reflink.h
+++ b/src/reflink.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef fooreflinkhfoo
 #define fooreflinkhfoo
 

--- a/src/rm-rf.c
+++ b/src/rm-rf.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <fcntl.h>
 #include <linux/fs.h>
 #include <linux/magic.h>

--- a/src/rm-rf.h
+++ b/src/rm-rf.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foormrfhfoo
 #define foormrfhfoo
 

--- a/src/signal-handler.c
+++ b/src/signal-handler.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include "signal-handler.h"
 #include "util.h"
 

--- a/src/signal-handler.h
+++ b/src/signal-handler.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef foosignalhandlerhfoo
 
 #include <signal.h>

--- a/src/siphash24.c
+++ b/src/siphash24.c
@@ -1,4 +1,6 @@
 /*
+   SPDX-License-Identifier: CC0-1.0
+
    SipHash reference C implementation
 
    Written in 2012 by

--- a/src/siphash24.h
+++ b/src/siphash24.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: CC0-1.0 */
+
 #ifndef foosiphash24hfoo
 
 #include <inttypes.h>

--- a/src/util.c
+++ b/src/util.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <ctype.h>
 #include <fcntl.h>
 #include <stdarg.h>

--- a/src/util.h
+++ b/src/util.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #ifndef fooutilhfoo
 #define fooutilhfoo
 

--- a/test-files/test-files.sh
+++ b/test-files/test-files.sh
@@ -1,4 +1,5 @@
 #!/bin/sh -ex
+# SPDX-License-Identifier: LGPL-2.1+
 
 cd "$(dirname "$0")"
 if [ "$1" != "clean" ]; then

--- a/test/http-server.py
+++ b/test/http-server.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: LGPL-2.1+
 
 PORT = 4321
 

--- a/test/meson-check-help.sh
+++ b/test/meson-check-help.sh
@@ -1,4 +1,5 @@
 #!/bin/sh -eu
+# SPDX-License-Identifier: LGPL-2.1+
 
 # output width
 if "$1"  --help | grep -v 'default:' | grep -E -q '.{80}.'; then

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,1 +1,3 @@
+# SPDX-License-Identifier: LGPL-2.1+
+
 notify_wait_sources = files('notify-wait.c'.split())

--- a/test/notify-wait.c
+++ b/test/notify-wait.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <fcntl.h>
 #include <signal.h>
 #include <stddef.h>

--- a/test/pseudo-ssh
+++ b/test/pseudo-ssh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: LGPL-2.1+
 
 # A tool that we can use like ssh, but instead of connecting anywhere simply
 # invokes the specified command locally. To be used via $CASYNC_SSH_PATH for

--- a/test/semaphore-run
+++ b/test/semaphore-run
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-License-Identifier: LGPL-2.1+
+
 DEVPKGS="pkg-config liblzma-dev libcurl4-openssl-dev libssl-dev libacl1-dev libfuse-dev zlib1g-dev libzstd-dev"
 
 echo

--- a/test/test-cachunk.c
+++ b/test/test-cachunk.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <fcntl.h>
 
 #include "cachunk.h"

--- a/test/test-cachunker-histogram.c
+++ b/test/test-cachunker-histogram.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <fcntl.h>
 #include <math.h>
 #include <pthread.h>

--- a/test/test-cachunker.c
+++ b/test/test-cachunker.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <assert.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/test/test-cadigest.c
+++ b/test/test-cadigest.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include "util.h"
 #include "cadigest.h"
 

--- a/test/test-caencoder.c
+++ b/test/test-caencoder.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/test/test-caformat.c
+++ b/test/test-caformat.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <stdio.h>
 #include <fcntl.h>
 

--- a/test/test-caindex.c
+++ b/test/test-caindex.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <stdio.h>
 
 #include "util.h"

--- a/test/test-calc-digest.c
+++ b/test/test-calc-digest.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <stdio.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/test/test-camakebst.c
+++ b/test/test-camakebst.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include "camakebst.h"
 #include "util.h"
 

--- a/test/test-caorigin.c
+++ b/test/test-caorigin.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include "caorigin.h"
 
 int main(int argc, char *argv[]) {

--- a/test/test-casync.c
+++ b/test/test-casync.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <sys/stat.h>
 #include <fcntl.h>
 

--- a/test/test-cautil.c
+++ b/test/test-cautil.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include "cautil.h"
 #include "util.h"
 

--- a/test/test-fuse.sh.in
+++ b/test/test-fuse.sh.in
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
+# SPDX-License-Identifier: LGPL-2.1+
 
 PARAMS="--with=fuse"
 

--- a/test/test-nbd.sh.in
+++ b/test/test-nbd.sh.in
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
+# SPDX-License-Identifier: LGPL-2.1+
 
 if [ -z "$1" ] ; then
     DIGEST=sha512-256

--- a/test/test-script-gzip.sh.in
+++ b/test/test-script-gzip.sh.in
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
+# SPDX-License-Identifier: LGPL-2.1+
 
 # This is the same as test-script.sh, except that we force the compression
 # algorithm to be gzip.

--- a/test/test-script-sha256.sh.in
+++ b/test/test-script-sha256.sh.in
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
+# SPDX-License-Identifier: LGPL-2.1+
 
 # This is the same as test-script.sh, except that we force the digest to be
 # sha256, in order to detect potential incompatibilities with the remoting

--- a/test/test-script-xz.sh.in
+++ b/test/test-script-xz.sh.in
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
+# SPDX-License-Identifier: LGPL-2.1+
 
 # This is the same as test-script.sh, except that we force the compression
 # algorithm to be xz.

--- a/test/test-script.sh.in
+++ b/test/test-script.sh.in
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
+# SPDX-License-Identifier: LGPL-2.1+
 
 if [ -z "$1" ] ; then
     DIGEST=sha512-256

--- a/test/test-util.c
+++ b/test/test-util.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
 #include <fcntl.h>
 
 #include "util.h"


### PR DESCRIPTION
This follows what the kernel is doing, c.f.
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=5fd54ace4721fc5ce2bb5aef6318fcf17f421460.