### PR TITLE
test-nbd: avoid false-positive due to nbd readiness

### DIFF
--- a/test/test-nbd.sh.in
+++ b/test/test-nbd.sh.in
@@ -41,7 +41,11 @@ if [ `id -u` == 0 ] ; then
     if test -e /dev/nbd0 ; then
         MKDEV_PID=`@top_builddir@/notify-wait @top_builddir@/casync $PARAMS mkdev $SCRATCH_DIR/test.caibx $SCRATCH_DIR/test-node`
 
-        dd if=$SCRATCH_DIR/test-node bs=102400 count=80 | @top_builddir@/test-calc-digest $DIGEST > $SCRATCH_DIR/mkdev.digest
+        until [ ${rc} -eq 0 -o ${retry} -gt 5 ]; do
+            sleep $((retry++))s
+            dd if=$SCRATCH_DIR/test-node bs=102400 count=80 | @top_builddir@/test-calc-digest $DIGEST > $SCRATCH_DIR/mkdev.digest
+            rc=${PIPESTATUS[0]}
+        done
 
         diff -q $SCRATCH_DIR/test.digest $SCRATCH_DIR/mkdev.digest
 


### PR DESCRIPTION
In automated tests depending on the environment several cases hit an error
which appears like:
  ValueError: Invalid file object: <_io.BufferedReader name=5>
  FAILED: meson-test

In the background of this timeout there is the dd of test-nbd
failing due to test-node not being ready yet. That makes the test script to
fail and end up a zombified process.

After some time meson cleans up as an error.
To avoid that issue retry the dd with an incrementing wait.
That means in most cases no slowdown at all, while in affected cases a
correct test execution.

fixes 113

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>