### PR TITLE
properly wait for "casync mkdev" nbd devices to appear with udev

### DIFF
--- a/TODO
+++ b/TODO
@@ -37,3 +37,5 @@ LATER:
 * send progress information via sd_notify(), so that people can wrap casync nicely in UIs
 * maybe turn "recursive" mode into a numeric value specifying how far to descend?
 * make "casync stat" work on a directory with a subpath
+* save/restore xfs/ext4 projid
+* tweak chunker: shift cut to last "marker".

--- a/meson.build
+++ b/meson.build
@@ -114,7 +114,6 @@ libzstd = dependency('libzstd',
 
 libacl = cc.find_library('acl')
 
-
 if get_option('fuse')
         libfuse = dependency('fuse',
                              version : '>= 2.6')
@@ -129,6 +128,13 @@ else
         libselinux = []
 endif
 conf.set10('HAVE_SELINUX', get_option('selinux'))
+
+if get_option('udev')
+        libudev = dependency('libudev')
+else
+        libudev = []
+endif
+conf.set10('HAVE_UDEV', get_option('udev'))
 
 threads = dependency('threads')
 math = cc.find_library('m')
@@ -159,6 +165,7 @@ casync = executable(
                 libfuse,
                 liblzma,
                 libselinux,
+                libudev,
                 libz,
                 libzstd,
                 math,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,5 +5,7 @@ option('fuse', type : 'boolean', value : true,
        description : 'build the FUSE integration (requires fuse-devel)')
 option('selinux', type : 'boolean', value : true,
        description : 'build the SELinux backend (requires libselinux-devel)')
+option('udev', type : 'boolean', value : true,
+       description : 'build the libudev integration (requires libudev-devel)')
 option('man', type : 'boolean', value : true,
        description : 'build and install man pages (requires spinx-build')

--- a/src/cafuse.c
+++ b/src/cafuse.c
@@ -641,7 +641,7 @@ static int feature_flags_warning(CaSync *s) {
                 }
         }
 
-        unsupported = ff & ~(CA_FORMAT_WITH_FUSE|CA_FORMAT_EXCLUDE_NODUMP|CA_FORMAT_EXCLUDE_SUBMOUNTS);
+        unsupported = ff & ~(CA_FORMAT_WITH_FUSE|CA_FORMAT_SHA512_256|CA_FORMAT_EXCLUDE_SUBMOUNTS|CA_FORMAT_EXCLUDE_NODUMP);
         if (unsupported == 0)
                 return 0;
 

--- a/src/cafuse.c
+++ b/src/cafuse.c
@@ -704,7 +704,7 @@ int ca_fuse_run(CaSync *s, const char *what, const char *where, bool do_mkdir) {
                 }
 
                 if (r < 0) {
-                        log_error("Failed to establish FUSE mount: %m");
+                        log_error_errno(r, "Failed to establish FUSE mount: %m");
                         goto finish;
                 }
         }
@@ -713,7 +713,7 @@ int ca_fuse_run(CaSync *s, const char *what, const char *where, bool do_mkdir) {
         fuse = fuse_new(fc, NULL, &ops, sizeof(ops), s);
         if (!fuse) {
                 r = errno != 0 ? -abs(errno) : -ENOMEM;
-                log_error("Failed to allocate FUSE object: %m");
+                log_error_errno(r, "Failed to allocate FUSE object: %m");
                 goto finish;
         }
 
@@ -736,7 +736,7 @@ int ca_fuse_run(CaSync *s, const char *what, const char *where, bool do_mkdir) {
 
         r = fuse_loop(fuse);
         if (r < 0) {
-                log_error("Failed to run FUSE loop: %m");
+                log_error_errno(r, "Failed to run FUSE loop: %m");
                 goto finish;
         }
 

--- a/src/cafuse.c
+++ b/src/cafuse.c
@@ -735,13 +735,12 @@ int ca_fuse_run(CaSync *s, const char *what, const char *where, bool do_mkdir) {
         (void) send_notify("READY=1");
 
         r = fuse_loop(fuse);
+        if (IN_SET(r, -ESHUTDOWN, -EINTR) && quit)
+                r = 0;
         if (r < 0) {
                 log_error_errno(r, "Failed to run FUSE loop: %m");
                 goto finish;
         }
-
-        if (IN_SET(r, -ESHUTDOWN, -EINTR) && quit)
-                r = 0;
 
 finish:
         if (updated_signal_handlers)

--- a/src/cafuse.c
+++ b/src/cafuse.c
@@ -173,7 +173,7 @@ static int casync_readlink(
 
         r = ca_sync_current_target(instance, &target);
         if (r < 0)
-                return log_error_errno(r, "failed to get symlink target: %m");
+                return log_error_errno(r, "Failed to get symlink target: %m");
 
         strncpy(ret, target, size);
 

--- a/src/canbd.h
+++ b/src/canbd.h
@@ -38,6 +38,9 @@ int ca_block_device_get_path(CaBlockDevice *d, const char **ret);
 
 int ca_block_device_set_friendly_name(CaBlockDevice *d, const char *name);
 
+int ca_block_device_get_devnum(CaBlockDevice *d, dev_t *ret);
+int ca_block_device_get_poll_fd(CaBlockDevice *d);
+
 int ca_block_device_test_nbd(const char *name);
 
 #endif

--- a/src/log.c
+++ b/src/log.c
@@ -15,7 +15,10 @@ static int log_errorv(
         const char *fmt;
 
         fmt = strjoina(format, "\n");
-        errno = abs(error);
+
+        if (error != 0)
+                errno = abs(error);
+
         vfprintf(stderr, fmt, ap);
         errno = orig_errno;
         return -abs(error);

--- a/src/udev-util.h
+++ b/src/udev-util.h
@@ -1,0 +1,14 @@
+#ifndef fooudevutilhfoo
+#define fooudevutilhfoo
+
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
+#include "util.h"
+
+#include <libudev.h>
+
+DEFINE_TRIVIAL_CLEANUP_FUNC(struct udev*, udev_unref);
+DEFINE_TRIVIAL_CLEANUP_FUNC(struct udev_device*, udev_device_unref);
+DEFINE_TRIVIAL_CLEANUP_FUNC(struct udev_monitor*, udev_monitor_unref);
+
+#endif

--- a/test/semaphore-run
+++ b/test/semaphore-run
@@ -1,7 +1,7 @@
 #!/bin/sh
 # SPDX-License-Identifier: LGPL-2.1+
 
-DEVPKGS="pkg-config liblzma-dev libcurl4-openssl-dev libssl-dev libacl1-dev libfuse-dev zlib1g-dev libzstd-dev"
+DEVPKGS="pkg-config liblzma-dev libcurl4-openssl-dev libssl-dev libacl1-dev libfuse-dev zlib1g-dev libzstd-dev libudev-dev"
 
 echo
 echo "============= Installing amd64 build dependencies =============="

--- a/test/test-script.sh.in
+++ b/test/test-script.sh.in
@@ -8,7 +8,7 @@ else
 fi
 
 if [ -z "$2" ] ; then
-    COMPRESSION=gzip
+    COMPRESSION=zstd
 else
     COMPRESSION="$2"
 fi


### PR DESCRIPTION
This fixes #114 properly, by waiting with udev until the device node appeared and has been probed as valid.

Also, a number of other fixes