### PR TITLE
src/cadecoder: fix getpwnam_r() and getgrnam_r() return code handling

### DIFF
--- a/src/cadecoder.c
+++ b/src/cadecoder.c
@@ -2890,7 +2890,12 @@ static int name_to_uid(CaDecoder *d, const char *name, uid_t *ret) {
                         return -ENOMEM;
 
                 r = getpwnam_r(name, &pwbuf, buf, (size_t) bufsize, &pw);
-                if (r == 0 && pw) {
+                if (pw == NULL) {
+                        if (r == 0)
+                                return 1;
+                        else if (r != ERANGE)
+                                return r > 0 ? -r : -ESRCH;
+                } else {
 
                         free(d->cached_user_name);
                         d->cached_user_name = strdup(pw->pw_name);
@@ -2899,8 +2904,6 @@ static int name_to_uid(CaDecoder *d, const char *name, uid_t *ret) {
                         *ret = pw->pw_uid;
                         return 1;
                 }
-                if (r != ERANGE)
-                        return r > 0 ? -r : -ESRCH;
 
                 bufsize *= 2;
         }
@@ -2944,7 +2947,12 @@ static int name_to_gid(CaDecoder *d, const char *name, gid_t *ret) {
                         return -ENOMEM;
 
                 r = getgrnam_r(name, &grbuf, buf, (size_t) bufsize, &gr);
-                if (r == 0 && gr) {
+                if (gr == NULL) {
+                        if (r == 0)
+                                return 1;
+                        else if (r != ERANGE)
+                                return r > 0 ? -r : -ESRCH;
+                } else {
 
                         free(d->cached_group_name);
                         d->cached_group_name = strdup(gr->gr_name);
@@ -2953,8 +2961,6 @@ static int name_to_gid(CaDecoder *d, const char *name, gid_t *ret) {
                         *ret = gr->gr_gid;
                         return 1;
                 }
-                if (r != ERANGE)
-                        return r > 0 ? -r : -ESRCH;
 
                 bufsize *= 2;
         }


### PR DESCRIPTION
If for example a catar file contains a file whose owner is not existing
on the target system, getpwnam_r() will return 0 and set pw to NULL.

In the former return code handling, only r == 0 with pw *not* being NULL
was checked and properly handled.
For all other cases we fell into the error return conditional which only
checked for getting ERANGE and otherwise makes negative error numbers
from positive ones or returns -ESRCH for 'error' numbers being
non-negative.

Thus, for the case described above, we fell into the return code check
with having a non-negative return code '0' and thus simply returned
-ESRCH ('No such process') from name_to_uid() which is definitely the
wrong conclusion and leads to confusing error messages such as:

> Failed to run synchronizer: No such process

Instead we need an extra case to handle a successful call to
getpwnam_r() indicating that the entry we were looking for was not
found.

This patch resolved this for both name_to_uid() and name_to_gid() by
checking for pw == NULL as indication of unsuccessful call to
getpwnam_r() or getgrnam_r() with an additional conditional for
distinguishing an orderly return indicating no entry was found from a
real error.
This is also close to what the man page suggest as example code.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>