### PR TITLE
meson.build: make udev really optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -149,7 +149,7 @@ subdir('test')
 
 includes = include_directories('src')
 
-udevdir = dependency('udev').get_pkgconfig_variable('udevdir')
+udevdir = dependency('udev', required : false).get_pkgconfig_variable('udevdir')
 udevrulesdir = join_paths(udevdir, 'rules.d')
 
 subdir('doc')


### PR DESCRIPTION
setting udevdir implicitly always added udev as build dependency, making
it inappropriate for host tool builds.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>