### PR TITLE
Fix error message when setting max chunk size fails

### DIFF
--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -750,7 +750,7 @@ static int load_chunk_size(CaSync *s) {
         if (arg_chunk_size_max != 0) {
                 r = ca_sync_set_chunk_size_max(s, arg_chunk_size_max);
                 if (r < 0)
-                        return log_error_errno(r, "Failed to set minimum chunk size to %zu: %m", arg_chunk_size_min);
+                        return log_error_errno(r, "Failed to set maximum chunk size to %zu: %m", arg_chunk_size_max);
         }
 
         if (!arg_verbose)


### PR DESCRIPTION
I think this is a typo / copy paste mistake. Unfortunately I don't know how to trigger this message.