### PR TITLE
[test/http-server.py] Imports re-ordered

### DIFF
--- a/test/http-server.py
+++ b/test/http-server.py
@@ -3,8 +3,12 @@
 
 PORT = 4321
 
-import http.server, socketserver, os, sys, socket, time
-
+import http.server
+import os
+import socket
+import socketserver
+import sys
+import time
 os.chdir(sys.argv[1])
 
 if len(sys.argv) >= 3:


### PR DESCRIPTION
- Files: test/http-server.py
- Changes: Import re-ordered

According to PEP8's import section (Style Guide for Python) Imports should usually be on separate lines and order by alphabetical names

---

Acceptable:
```python
import os
import sys
```
Not Acceptable:
```python
import os,sys
```
---
