### PR TITLE
src/util.h: add missing sys/types.h include for mode_t in musl systems

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/vfs.h>
+#include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Allows compilation on Void Linux x86_64-musl arch.