### PR TITLE
meson: drop -ffast-math from gcc options

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,6 @@ c_args = '''
         -Werror=sign-compare
         -Wdate-time
         -Wnested-externs
-        -ffast-math
         -fno-common
         -fdiagnostics-show-option
         -fno-strict-aliasing


### PR DESCRIPTION
We don't do much floating point processing, and given that #133 has
shown that the inaccuracies introduced by -ffast-math have an effect on
us, let's sidestep the whole issue and turn off the whole thing for us.

After all reproducibility is supposed to be a big thing in casync, hence
we should really come to the same results on all archs, and all
compilers and all versions thereof.

See: #133