### PR TITLE
AT_SYMLINK_NOFOLLOW in fchmodat() is not supported.

### DIFF
--- a/src/cadecoder.c
+++ b/src/cadecoder.c
@@ -3681,7 +3681,7 @@ static int ca_decoder_finalize_child(CaDecoder *d, CaDecoderNode *n, CaDecoderNo
                         else {
                                 assert(dir_fd >= 0);
 
-                                r = fchmodat(dir_fd, name, new_mode, AT_SYMLINK_NOFOLLOW);
+                                r = fchmodat(dir_fd, name, new_mode, 0);
                         }
                         if (r < 0)
                                 return -errno;
@@ -3696,7 +3696,7 @@ static int ca_decoder_finalize_child(CaDecoder *d, CaDecoderNode *n, CaDecoderNo
                         else {
                                 assert(dir_fd >= 0);
 
-                                r = fchmodat(dir_fd, name, read_le64(&child->entry->mode) & 07777, AT_SYMLINK_NOFOLLOW);
+                                r = fchmodat(dir_fd, name, read_le64(&child->entry->mode) & 07777, 0);
                         }
                         if (r < 0)
                                 return -errno;


### PR DESCRIPTION
This addresses issue #88 (https://github.com/systemd/casync/issues/88) "extracting char devices: Failed to run synchronizer: Operation not supported".

When extracting character or block devices, fchmodat() is called with flag AT_SYMLINK_NOFOLLOW.
According to the documentation (man page), this is not supported and hence returns ENOTSUP.
The only supported flag is 0.