### PR TITLE
casync-tool: Fix compile without udev support

### DIFF
--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -29,7 +29,7 @@
 #include "signal-handler.h"
 #include "util.h"
 
-#ifdef HAVE_UDEV
+#if HAVE_UDEV
 #include <libudev.h>
 #include "udev-util.h"
 #endif


### PR DESCRIPTION
HAVE_UDEV is always defined in config.h as 1 or 0 so the check for udev
support must use 'if' directive instead of 'ifdef'.

Signed-off-by: Mihai Serban <mihai.serban@gmail.com>