### PR TITLE
Ensure scratch file is writable

### DIFF
--- a/test/test-cache.sh.in
+++ b/test/test-cache.sh.in
@@ -47,6 +47,7 @@ touch casync/zzz-late/testc
 rm casync/NEWS
 
 # And update an existing one
+chmod +w casync/README.md
 echo xxx >> casync/README.md
 
 @top_builddir@/casync list > $SCRATCH_DIR/testx.list


### PR DESCRIPTION
Some build environments check out source code as readonly. When it is copied into the scratch dir for the test-cache test, the files are copied as readonly, and appending to README.md in the scratch directory fails. So first make the file writable before appending to it.