### PR TITLE
meson: allow overriding udevdir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -149,7 +149,11 @@ subdir('test')
 
 includes = include_directories('src')
 
-udevdir = dependency('udev', required : false).get_pkgconfig_variable('udevdir')
+udevdir = get_option('udevdir')
+if udevdir == ''
+        udevdir = dependency('udev',
+                             required : false).get_pkgconfig_variable('udevdir')
+endif
 udevrulesdir = join_paths(udevdir, 'rules.d')
 
 subdir('doc')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,5 +7,7 @@ option('selinux', type : 'boolean', value : true,
        description : 'build the SELinux backend (requires libselinux-devel)')
 option('udev', type : 'boolean', value : true,
        description : 'build the libudev integration (requires libudev-devel)')
+option('udevdir', type : 'string',
+       description : 'udev directory containing rules.d to install rules into')
 option('man', type : 'boolean', value : true,
        description : 'build and install man pages (requires sphinx-build')


### PR DESCRIPTION
In some environments (such as NixOS and GNU Guix), the udevdir returned by `pkg-config` is not the directory that rules should be installed into. Nix and Guix install packages in their own directory tree, which is read-only to other packages. Rather than installing rules into `rules.d` in udev's directory tree, packages should have `usr/lib/udev/rules.d` under their own directory tree. To support these environments, allow providing the udevdir, and fall back to `pkg-config` when it is not set.