### PR TITLE
add falloc dep

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -9,6 +9,7 @@
 #include <time.h>
 #include <linux/fs.h>
 #include <linux/msdos_fs.h>
+#include <linux/falloc.h>
 
 #if USE_SYS_RANDOM_H
 #  include <sys/random.h>


### PR DESCRIPTION
Hi all: 

The objective here is to be able to build casync in centos7.
---

2 things stop us from building casync in centos7, one is the old version of libcurl and that  FALLOC_FL_KEEP_SIZE and FALLOC_FL_PUNCH_HOLE are not defined.

curl is relatively simple to fix, there are always good souls on the internet that have build this package for us, or we can build a modern libcurl in centos7 fairly easy.


the easy way to include FALLOC macros, is to explicitly include the `linux/falloc.h` header. my theory  is that centos7's fcntl.h does not include falloc.h, but not 100% sure about that


to test this i build in debian9 and centos7, i plan to do another PR to document how to compile on this platforms (if that is alright with you guys). my testing consisted on compiling casuync, serialize my dummy env home, and then mount it

debian9 test
-----
```shell
apt update
apt install -y python3-pip liblzma-dev libcurl4-gnutls-dev libssl-dev libzstd-dev zstd zlibc zlib1g-dev libacl1-dev libfuse-dev libudev-dev python3-sphinx
pip3 install meson ninja

# now meson
/usr/src/casync$ meson build
The Meson build system
Version: 0.46.1
Source dir: /usr/src/casync
Build dir: /usr/src/casync/build
Build type: native build
Project name: casync
Native C compiler: cc (gcc 6.3.0 "cc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516")
Build machine cpu family: x86_64
Build machine cpu: x86_64
....
Program test-cache.sh found: YES (/usr/src/casync/build/test-cache.sh)
Configuring 75-casync.rules using configuration
Program test/meson-check-help.sh found: YES (/usr/src/casync/test/meson-check-help.sh)
Program git found: YES (/usr/bin/git)
Build targets in project: 25
Found ninja-1.8.2 at /usr/local/bin/ninja
'/usr/src/casync/build/casync-https' -> 'casync-http'
'/usr/src/casync/build/casync-ftp' -> 'casync-http'
'/usr/src/casync/build/casync-sftp' -> 'casync-http'

#now ninja
/usr/src/casync$ ninja -C build                                                                                                                                                                                                             
ninja: Entering directory `build'                                                                                                                                                                                                                           
[56/85] Generating man with a custom command.                                                                                                                                                                                                               
Running Sphinx v1.4.9                                                                                                                                                                                                                                       
loading pickled environment... not yet created                                                                                                                                                                                                              
building [mo]: targets for 0 po files that are out of date                                                                                                                                                                                                  
building [man]: all manpages
updating environment: 2 added, 0 changed, 0 removed
reading sources... [ 50%] casync
reading sources... [100%] index

looking for now-outdated files... none found
pickling environment... done
checking consistency... done
writing... casync.1 { }
build succeeded.
[85/85] Linking target test-calc-digest.

/usr/src/casync$ ./build/casync make --store /tmp/oh-my.castr /tmp/oh-my.caidx /home/
3bfc04be125f9b9783a7855f6efa9163d77b88e7170815a5dae320688c09e00c

/usr/src/casync$ sudo ./build/casync mount --store /tmp/oh-my.castr /tmp/oh-my.caidx /tmp/fake_home
Mounted: /tmp/fake_home
The following feature flags are not exposed in the mounted file system: user-names subvolume subvolume-ro acl selinux fcaps quota-projid

# and then check

vagrant@debian9:~$ ls -lla /tmp/fake_home/vagrant/
total 0
drwxr-xr-x 2 vagrant vagrant    0 May 24 00:46 .
drwxr-xr-x 2 root    root       0 May 24 00:41 ..
-rw-r--r-- 1 vagrant vagrant  220 May 24 00:41 .bash_logout
-rw-r--r-- 1 vagrant vagrant 3526 May 24 00:41 .bashrc
-rw-r--r-- 1 vagrant vagrant  675 May 24 00:41 .profile
drwx------ 2 vagrant vagrant    0 May 31 09:05 .ssh
vagrant@debian9:~$ ls -lla /home/vagrant/                       
total 24
drwxr-xr-x 3 vagrant vagrant 4096 May 24 00:46 .
drwxr-xr-x 3 root    root    4096 May 24 00:41 ..
-rw-r--r-- 1 vagrant vagrant  220 May 24 00:41 .bash_logout
-rw-r--r-- 1 vagrant vagrant 3526 May 24 00:41 .bashrc
-rw-r--r-- 1 vagrant vagrant  675 May 24 00:41 .profile
drwx------ 2 vagrant vagrant 4096 May 31 09:05 .ssh


```


centos7 test
----

```sh

yum -y install epel-release wget
yum -y install libmetalink

# get new curl
wget http://cbs.centos.org/kojifiles/packages/curl/7.43.0/1.el7/x86_64/curl-7.43.0-1.el7.x86_64.rpm http://cbs.centos.org/kojifiles/packages/curl/7.43.0/1.el7/x86_64/libcurl-7.43.0-1.el7.x86_64.rpm http://cbscentos.org/kojifiles/packages/curl/7.43.0/1.el7/x86_64/libcurl-devel-7.43.0-1.el7.x86_64.rpm http://cbs.centos.org/kojifiles/packages/curl/7.43.0/1.el7/x86_64/curl-debuginfo-7.43.0-1.el7.x86_64.rpm
rpm -Uvh curl*.rpm libcurl*.rpm

# install all of the things

yum -y install rsync gcc meson xz xz-devel openssl openssl-libs openssl-devel libzstd libzstd-devel libacl-devel fuse fuse-libs fuse-devel libudev libudev-devel python-sphinx

[vagrant@localhost casync]$ meson build                                           
The Meson build system                                                            
Version: 0.44.1                                                                   
Source dir: /usr/src/casync                                                       
Build dir: /usr/src/casync/build                                                  
Build type: native build                                                          
Project name: casync                                                              
Native C compiler: cc (gcc 4.8.5)                                                 
Build machine cpu family: x86_64                                                  
Build machine cpu: x86_64                                                         
Compiler for C supports argument -Wextra: YES                                     
Compiler for C supports argument -Werror=undef: YES                               
Compiler for C supports argument -Werror=format=2: YES                            
Compiler for C supports argument -Wformat-security: YES                           
Compiler for C supports argument -Wformat-nonliteral: YES                         
Compiler for C supports argument -Wlogical-op: YES                                
Compiler for C supports argument -Wmissing-include-dirs: YES                      
Compiler for C supports argument -Werror=old-style-definition: YES                
Compiler for C supports argument -Werror=pointer-arith: YES                       
Compiler for C supports argument -Winit-self: YES                                 
Compiler for C supports argument -Wdeclaration-after-statement: YES               
Compiler for C supports argument -Wfloat-equal: YES                               
Compiler for C supports argument -Wsuggest-attribute=noreturn: YES                
Compiler for C supports argument -Werror=missing-prototypes: YES                  
Compiler for C supports argument -Werror=implicit-function-declaration: YES       
Compiler for C supports argument -Werror=missing-declarations: YES                
...
Program test-nbd.sh found: YES (/usr/src/casync/build/test-nbd.sh)
Configuring test-fuse.sh using configuration
Program test-fuse.sh found: YES (/usr/src/casync/build/test-fuse.sh)
Configuring test-cache.sh using configuration
Program test-cache.sh found: YES (/usr/src/casync/build/test-cache.sh)
Configuring 75-casync.rules using configuration
Program test/meson-check-help.sh found: YES (/usr/src/casync/test/meson-check-help.sh)
Program git found: NO
Build targets in project: 23
Found ninja-1.7.2 at /usr/bin/ninja-build
‘/usr/src/casync/build/casync-https’ -> ‘casync-http’
‘/usr/src/casync/build/casync-ftp’ -> ‘casync-http’
‘/usr/src/casync/build/casync-sftp’ -> ‘casync-http’
[vagrant@localhost casync]$ ninja-build -C build
ninja: Entering directory `build'
[47/85] Generating man with a custom command.
Running Sphinx v1.1.3
loading pickled environment... not yet created
building [man]: all manpages
updating environment: 2 added, 0 changed, 0 removed
reading sources... [ 50%] casync
reading sources... [100%] index

/usr/src/casync/doc/index.rst:8: ERROR: Error in "toctree" directive:
unknown option: "caption".

.. toctree::
   :maxdepth: 2
   :caption: Contents:
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
writing... casync.1 { }
build succeeded, 1 warning.

# test
[vagrant@localhost casync]$  ./build/casync make --store /tmp/oh-my.castr /tmp/oh-my.caidx /home/
bb591de268555a29bf15e876036788fbc439359394e747ee13e01289fc181dd1


[vagrant@localhost casync]$ sudo  ./build/casync mount --store /tmp/oh-my.castr /tmp/oh-my.caidx /tmp/fake_home
fuse: failed to access mountpoint /tmp/fake_home: No such file or directory
Mounted: /tmp/fake_home
The following feature flags are not exposed in the mounted file system: user-names subvolume subvolume-ro acl selinux fcaps quota-projid

[vagrant@localhost ~]$ sudo ls -lla /tmp/fake_home/vagrant/
total 0
drwx------. 2 vagrant vagrant       0 May 31 16:05 .
drwxr-xr-x. 2 root    root          0 May 12 18:54 ..
-rw-r--r--. 1 vagrant vagrant      18 Apr 11 00:53 .bash_logout
-rw-r--r--. 1 vagrant vagrant     193 Apr 11 00:53 .bash_profile
-rw-r--r--. 1 vagrant vagrant     231 Apr 11 00:53 .bashrc
-rw-r--r--. 1 root    root     281296 Jul 12  2015 curl-7.43.0-1.el7.x86_64.rpm
-rw-r--r--. 1 root    root    1314732 Jul 12  2015 curl-debuginfo-7.43.0-1.el7.x86_64.rpm
-rw-r--r--. 1 root    root     247640 Jul 12  2015 libcurl-7.43.0-1.el7.x86_64.rpm
-rw-r--r--. 1 root    root     598680 Jul 12  2015 libcurl-devel-7.43.0-1.el7.x86_64.rpm
drwx------. 2 vagrant vagrant       0 May 31 16:04 .ssh
[vagrant@localhost ~]$ sudo ls -lla /home/vagrant/
total 2404
drwx------. 3 vagrant vagrant     240 May 31 16:05 .
drwxr-xr-x. 3 root    root         21 May 12 18:54 ..
-rw-r--r--. 1 vagrant vagrant      18 Apr 11 00:53 .bash_logout
-rw-r--r--. 1 vagrant vagrant     193 Apr 11 00:53 .bash_profile
-rw-r--r--. 1 vagrant vagrant     231 Apr 11 00:53 .bashrc
-rw-r--r--. 1 root    root     281296 Jul 12  2015 curl-7.43.0-1.el7.x86_64.rpm
-rw-r--r--. 1 root    root    1314732 Jul 12  2015 curl-debuginfo-7.43.0-1.el7.x86_64.rpm
-rw-r--r--. 1 root    root     247640 Jul 12  2015 libcurl-7.43.0-1.el7.x86_64.rpm
-rw-r--r--. 1 root    root     598680 Jul 12  2015 libcurl-devel-7.43.0-1.el7.x86_64.rpm
drwx------. 2 vagrant vagrant      29 May 31 16:04 .ssh


```

EDIT: adding what was i trying to fix:
Without this change, on centos7 everithing goes well until the `ninja-build` where

```
[root@localhost casync]# ninja-build -C build
ninja: Entering directory `build'
[40/85] Compiling C object 'src/shared@sta/util.c.o'.
FAILED: src/shared@sta/util.c.o
cc  -Isrc/shared@sta -Isrc -I../src -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu99 -O0 -g -Wextra -Werror=undef -Werror=format=2 -Wformat-security -Wformat-nonliteral -Wlogical-op -Wmissing-include-dirs -Werror=old-style-definition -Werror=pointer-arith -Winit-self -Wdeclaration-after-statement -Wfloat-equal -Wsuggest-attribute=noreturn -Werror=missing-prototypes -Werror=implicit-function-declaration -Werror=missing-declarations -Werror=return-type -Werror=shadow -Wstrict-prototypes -Wredundant-decls -Wmissing-noreturn -Wendif-labels -Wstrict-aliasing=2 -Wwrite-strings -Wno-unused-parameter -Wno-missing-field-initializers -Wno-unused-result -Werror=overflow -Werror=sign-compare -Wnested-externs -fno-common -fdiagnostics-show-option -fno-strict-aliasing -fvisibility=hidden -fstack-protector -fstack-protector-strong -fPIE --param=ssp-buffer-size=4 -include config.h -fPIC -MMD -MQ 'src/shared@sta/util.c.o' -MF 'src/shared@sta/util.c.o.d' -o 'src/shared@sta/util.c.o' -c ../src/util.c
../src/util.c: In function ‘write_zeroes’:
../src/util.c:115:35: error: ‘FALLOC_FL_PUNCH_HOLE’ undeclared (first use in this function)
                 if (fallocate(fd, FALLOC_FL_PUNCH_HOLE|FALLOC_FL_KEEP_SIZE, p, l) < 0) {
                                   ^
../src/util.c:115:35: note: each undeclared identifier is reported only once for each function it appears in
../src/util.c:115:56: error: ‘FALLOC_FL_KEEP_SIZE’ undeclared (first use in this function)
                 if (fallocate(fd, FALLOC_FL_PUNCH_HOLE|FALLOC_FL_KEEP_SIZE, p, l) < 0) {
                                                        ^
[41/85] Compiling C object 'casync@exe/src_canbd.c.o'.
ninja: build stopped: subcommand failed.
```

