### PR TITLE
meson.build: allow udevrulesdir to be set as option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -149,8 +149,11 @@ subdir('test')
 
 includes = include_directories('src')
 
-udevdir = dependency('udev', required : false).get_pkgconfig_variable('udevdir')
-udevrulesdir = join_paths(udevdir, 'rules.d')
+udevrulesdir = get_option('udevrulesdir')
+if udevrulesdir == ''
+        udev = dependency('udev', required : false)
+        udevrulesdir = join_paths(udev.get_pkgconfig_variable('udevdir'), 'rules.d')
+endif
 
 subdir('doc')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,5 +7,7 @@ option('selinux', type : 'boolean', value : true,
        description : 'build the SELinux backend (requires libselinux-devel)')
 option('udev', type : 'boolean', value : true,
        description : 'build the libudev integration (requires libudev-devel)')
+option('udevrulesdir', type : 'string', value: '',
+       description: 'Path where udev rules are installed to (Defaults to udevdir specified in udev.pc)')
 option('man', type : 'boolean', value : true,
        description : 'build and install man pages (requires sphinx-build')


### PR DESCRIPTION
Also aligns logic to how its handled in https://github.com/libfuse/libfuse/