### PR TITLE
build: check for renameat2()/copy_file_range() with _GNU_SOURCE

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -74,8 +74,10 @@ conf.set('SIZEOF_UID_T', cc.sizeof('uid_t', prefix : '#include <sys/types.h>'))
 conf.set('SIZEOF_GID_T', cc.sizeof('gid_t', prefix : '#include <sys/types.h>'))
 
 foreach ident : [
-        ['renameat2',         '''#include <stdio.h>'''],
-        ['copy_file_range',   '''#include <sys/syscall.h>
+        ['renameat2',         '''#define _GNU_SOURCE
+                                 #include <stdio.h>'''],
+        ['copy_file_range',   '''#define _GNU_SOURCE
+                                 #include <sys/syscall.h>
                                  #include <unistd.h>'''],
 ]
         have = cc.has_function(ident[0], prefix : ident[1])


### PR DESCRIPTION
The config.h which we generate doesn't apply for checks and those
functions are available only when _GNU_SOURCE is defined.

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>