### PR TITLE
mtree: follow-up all type=dir entries with ".."

### DIFF
--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -1870,6 +1870,19 @@ static int list_one_file(const char *arg0, CaSync *s, bool *toplevel_shown) {
                         /* End this in a newline — unless this is a regular file,
                          * in which case we'll print the payload checksum shortly */
                         putchar('\n');
+
+                /*
+                 * After each directory entry, we "go back" to the top-level.
+                 * This is necessary because the mtree(8) format assumes that
+                 * directories are listed hierarchically and that entries
+                 * succeeding a directory are lexically its children. In casync
+                 * we generate full pathnames and don't use this structure, so
+                 * we need to avoid other tools from misunderstanding the paths
+                 * we generate.
+                 */
+                if (S_ISDIR(mode))
+                        puts("..");
+
         } else {
                 const char *target = NULL, *user = NULL, *group = NULL;
                 uint64_t mtime = UINT64_MAX, size = UINT64_MAX, offset = UINT64_MAX;


### PR DESCRIPTION
In the mtree(8) format, each directory entry is treated as a parent
entry for subsequent entries (which are then considered to be lexically
children of their parent when figuring out what paths to compare for
manifest verification).

'casync mtree' outputs a fairly unconventional "flat" version of the
mtree(8) format, and as a result didn't handle this correctly in the
past. The most trivial way of handling the type=dir problem is to negate
it after each entry with a ".." entry. Because this acts on the node
level, having nodes with names like "a/b/c" doesn't cause an issue.

This is necessary for compatibility with go-mtree. It should be noted
that this change is still not sufficient for compatibility with FreeBSD
mtree(8), which does not permit "/" characters in node names. Supporting
this would require us to make significant changes to how generation
works (because we'd need to output a hierarchy-friendly format which
would require some more housekeeping). This is a stop-gap solution to at
least end up with basic compatibility.

Fixes: systemd/casync#167 vbatts/go-mtree#146
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>