### PR TITLE
meson.build: pass -D_GNU_SOURCE when checking for functions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -78,7 +78,7 @@ foreach ident : [
         ['copy_file_range',   '''#include <sys/syscall.h>
                                  #include <unistd.h>'''],
 ]
-        have = cc.has_function(ident[0], prefix : ident[1])
+        have = cc.has_function(ident[0], args : '-D_GNU_SOURCE', prefix : ident[1])
         conf.set10('HAVE_' + ident[0].to_upper(), have)
 endforeach
 


### PR DESCRIPTION
As described in #166, -D_GNU_SOURCE needs to be passed to the meson function
availability checker. h/t to @tomeon for providing a link to the solution as
well.

Fixes #166