### PR TITLE
util: missing include for falloc

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -8,6 +8,7 @@
 #include <sys/wait.h>
 #include <time.h>
 #include <linux/fs.h>
+#include <linux/falloc.h>
 #include <linux/msdos_fs.h>
 
 #if USE_SYS_RANDOM_H


### PR DESCRIPTION
On centos7 (gcc 4.8.5) this include is needed and not derived otherwise

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>