### PR TITLE
Add --log-level option

### DIFF
--- a/doc/casync.rst
+++ b/doc/casync.rst
@@ -151,6 +151,7 @@ Options
 General options:
 
 --help, -h                      Show terse help output
+--log-level=<LEVEL>, -l         Set log level (debug, info, err)
 --verbose, -v                   Show terse status information during runtime
 --dry-run, -n                   Only print what would be removed with **gc**
 --store=PATH                    The primary chunk store to use

--- a/src/log.c
+++ b/src/log.c
@@ -10,6 +10,27 @@
 
 static int cached_log_level = -1;
 
+static int level_from_string(const char *str) {
+        if (STR_IN_SET(str, "emerg", "emergency", "0"))
+                return LOG_EMERG;
+        else if (STR_IN_SET(str, "alert", "1"))
+                return LOG_ALERT;
+        else if (STR_IN_SET(str, "crit", "critical", "2"))
+                return LOG_CRIT;
+        else if (STR_IN_SET(str, "err", "error", "3"))
+                return LOG_ERR;
+        else if (STR_IN_SET(str, "warn", "warning", "4"))
+                return LOG_WARNING;
+        else if (STR_IN_SET(str, "notice", "5"))
+                return LOG_NOTICE;
+        else if (STR_IN_SET(str, "info", "6"))
+                return LOG_INFO;
+        else if (STR_IN_SET(str, "debug", "7"))
+                return LOG_DEBUG;
+        else
+                return -EINVAL;
+}
+
 static int get_log_level(void) {
         if (cached_log_level < 0) {
                 const char *e;
@@ -17,22 +38,8 @@ static int get_log_level(void) {
                 cached_log_level = LOG_INFO;
 
                 e = getenv("CASYNC_LOG_LEVEL");
-                if (e) {
-                        if (STR_IN_SET(e, "emerg", "emergency", "0"))
-                                cached_log_level = LOG_EMERG;
-                        else if (STR_IN_SET(e, "alert", "1"))
-                                cached_log_level = LOG_ALERT;
-                        else if (STR_IN_SET(e, "crit", "critical", "2"))
-                                cached_log_level = LOG_CRIT;
-                        else if (STR_IN_SET(e, "err", "error", "3"))
-                                cached_log_level = LOG_ERR;
-                        else if (STR_IN_SET(e, "warn", "warning", "4"))
-                                cached_log_level = LOG_WARNING;
-                        else if (STR_IN_SET(e, "notice", "5"))
-                                cached_log_level = LOG_NOTICE;
-                        else if (STR_IN_SET(e, "debug", "7"))
-                                cached_log_level = LOG_DEBUG;
-                }
+                if (e)
+                        set_log_level_from_string(e);
         }
 
         return cached_log_level;
@@ -40,6 +47,17 @@ static int get_log_level(void) {
 
 void set_log_level(int level) {
         cached_log_level = level;
+}
+
+int set_log_level_from_string(const char *str) {
+        int level;
+
+        level = level_from_string(str);
+        if (level < 0)
+                return level;
+
+        cached_log_level = level;
+        return level;
 }
 
 static int log_fullv(

--- a/src/log.h
+++ b/src/log.h
@@ -38,3 +38,4 @@ static inline int log_oom(void) {
         } while(false)
 
 void set_log_level(int level);
+int set_log_level_from_string(const char *str);


### PR DESCRIPTION
Now the log level can be set with:

    casync --log-level debug|info|error ...

This command-line argument overrides the environment variable
`CASYNC_LOG_LEVEL`.

Closes: #185
Signed-off-by: Arnaud Rebillout <arnaud.rebillout@collabora.com>