### PR TITLE
casync extract: Add time statistics

### DIFF
--- a/src/cadecoder.c
+++ b/src/cadecoder.c
@@ -29,6 +29,7 @@
 #include "reflink.h"
 #include "rm-rf.h"
 #include "siphash24.h"
+#include "time-util.h"
 #include "util.h"
 
 /* #undef EINVAL */

--- a/src/caencoder.c
+++ b/src/caencoder.c
@@ -39,6 +39,7 @@
 #include "quota-projid.h"
 #include "realloc-buffer.h"
 #include "siphash24.h"
+#include "time-util.h"
 #include "util.h"
 
 /* #undef EINVAL */

--- a/src/cafuse.c
+++ b/src/cafuse.c
@@ -11,6 +11,7 @@
 #include "cafuse.h"
 #include "notify.h"
 #include "signal-handler.h"
+#include "time-util.h"
 #include "util.h"
 
 static CaSync *instance = NULL;

--- a/src/calocation.c
+++ b/src/calocation.c
@@ -6,6 +6,7 @@
 #include <sys/stat.h>
 
 #include "calocation.h"
+#include "time-util.h"
 #include "util.h"
 #include "realloc-buffer.h"
 

--- a/src/canbd.c
+++ b/src/canbd.c
@@ -16,6 +16,7 @@
 #include <unistd.h>
 
 #include "canbd.h"
+#include "time-util.h"
 #include "util.h"
 
 #define NBD_MAX 1024

--- a/src/caremote.c
+++ b/src/caremote.c
@@ -15,6 +15,7 @@
 #include "def.h"
 #include "realloc-buffer.h"
 #include "rm-rf.h"
+#include "time-util.h"
 #include "util.h"
 
 /* #undef EBADMSG */

--- a/src/caseed.c
+++ b/src/caseed.c
@@ -14,6 +14,7 @@
 #include "def.h"
 #include "realloc-buffer.h"
 #include "rm-rf.h"
+#include "time-util.h"
 #include "util.h"
 
 /* #undef EINVAL */

--- a/src/caseed.c
+++ b/src/caseed.c
@@ -48,6 +48,9 @@ struct CaSeed {
 
         uint64_t n_requests;
         uint64_t n_request_bytes;
+
+        uint64_t first_step_nsec;
+        uint64_t last_step_nsec;
 };
 
 CaSeed *ca_seed_new(void) {
@@ -471,9 +474,15 @@ int ca_seed_step(CaSeed *s) {
                 return -EALREADY;
 
         if (!s->cache_chunks && !s->cache_hardlink) {
+                if (s->last_step_nsec == 0)
+                        s->last_step_nsec = now(CLOCK_MONOTONIC);
+
                 s->ready = true;
                 return CA_SEED_READY;
         }
+
+        if (s->first_step_nsec == 0)
+                s->first_step_nsec = now(CLOCK_MONOTONIC);
 
         r = ca_seed_open(s);
         if (r < 0)
@@ -493,6 +502,9 @@ int ca_seed_step(CaSeed *s) {
                         r = ca_seed_cache_final_chunk(s);
                         if (r < 0)
                                 return r;
+
+                        if (s->last_step_nsec == 0)
+                                s->last_step_nsec = now(CLOCK_MONOTONIC);
 
                         s->ready = true;
                         return CA_SEED_READY;
@@ -923,5 +935,23 @@ int ca_seed_get_request_bytes(CaSeed *s, uint64_t *ret) {
                 return -ENOTTY;
 
         *ret = s->n_request_bytes;
+        return 0;
+}
+
+int ca_seed_get_seeding_time_nsec(CaSeed *s, uint64_t *ret) {
+        if (!s)
+                return -EINVAL;
+        if (!ret)
+                return -EINVAL;
+
+        if (!s->cache_chunks)
+                return -ENOTTY;
+
+        if (s->first_step_nsec == 0 || s->last_step_nsec == 0)
+                return -ENODATA;
+        if (s->first_step_nsec > s->last_step_nsec)
+                return -ENODATA;
+
+        *ret = s->last_step_nsec - s->first_step_nsec;
         return 0;
 }

--- a/src/caseed.h
+++ b/src/caseed.h
@@ -47,5 +47,6 @@ int ca_seed_get_file_root(CaSeed *s, CaFileRoot **ret);
 
 int ca_seed_get_requests(CaSeed *s, uint64_t *ret);
 int ca_seed_get_request_bytes(CaSeed *s, uint64_t *ret);
+int ca_seed_get_seeding_time_nsec(CaSeed *s, uint64_t *ret);
 
 #endif

--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -27,6 +27,7 @@
 #include "notify.h"
 #include "parse-util.h"
 #include "signal-handler.h"
+#include "time-util.h"
 #include "util.h"
 
 #if HAVE_UDEV

--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -974,6 +974,7 @@ static int verbose_print_done_extract(CaSync *s) {
         uint64_t n_local_requests = UINT64_MAX, n_seed_requests = UINT64_MAX, n_remote_requests = UINT64_MAX;
         uint64_t n_local_bytes = UINT64_MAX, n_seed_bytes = UINT64_MAX, n_remote_bytes = UINT64_MAX;
         uint64_t total_requests = 0, total_bytes = 0;
+        uint64_t nsec = 0, runtime_nsec = 0;
         int r;
 
         if (!arg_verbose)
@@ -1081,6 +1082,34 @@ static int verbose_print_done_extract(CaSync *s) {
                 log_info("Bytes used from remote store: %s (%" PRIu64 "%%)",
                          format_bytes(buffer, sizeof(buffer), n_remote_bytes),
                          total_bytes > 0 ? n_remote_bytes * 100U / total_bytes : 0);
+
+        r = ca_sync_get_runtime_nsec(s, &runtime_nsec);
+        if (!IN_SET(r, -ENODATA)) {
+                if (r < 0)
+                        return log_error_errno(r, "Failed to determine runtime: %m");
+        }
+
+        r = ca_sync_get_seed_seeding_time_nsec(s, &nsec);
+        if (!IN_SET(r, -ENODATA, -ENOTTY)) {
+                if (r < 0)
+                        return log_error_errno(r, "Failed to determine seeding time: %m");
+
+                log_info("Time spent seeding: %s (%" PRIu64 "%%)",
+                         format_timespan(buffer, sizeof(buffer), nsec, NSEC_PER_MSEC),
+                         runtime_nsec > 0 ? nsec * 100U / runtime_nsec : 0);
+        }
+
+        r = ca_sync_get_decoding_time_nsec(s, &nsec);
+        if (!IN_SET(r, -ENODATA, -ENOTTY)) {
+                if (r < 0)
+                        return log_error_errno(r, "Failed to determine decoding time: %m");
+
+                log_info("Time spent decoding: %s (%" PRIu64 "%%)",
+                         format_timespan(buffer, sizeof(buffer), nsec, NSEC_PER_MSEC),
+                         runtime_nsec > 0 ? nsec * 100U / runtime_nsec : 0);
+         }
+
+        log_info("Total extract time: %s", format_timespan(buffer, sizeof(buffer), runtime_nsec, NSEC_PER_MSEC));
 
         return 1;
 }

--- a/src/casync.c
+++ b/src/casync.c
@@ -4250,6 +4250,31 @@ int ca_sync_get_seed_request_bytes(CaSync *s, uint64_t *ret) {
         return 0;
 }
 
+int ca_sync_get_seed_seeding_time_nsec(CaSync *s, uint64_t *ret) {
+        uint64_t sum = 0;
+        size_t i;
+        int r;
+
+        if (!s)
+                return -EINVAL;
+        if (!ret)
+                return -EINVAL;
+
+        /* We can sum seeding times since seeds are processed one after another */
+        for (i = 0; i < s->n_seeds; i++) {
+                uint64_t x;
+
+                r = ca_seed_get_seeding_time_nsec(s->seeds[i], &x);
+                if (r < 0)
+                        return r;
+
+                sum += x;
+        }
+
+        *ret = sum;
+        return 0;
+}
+
 int ca_sync_get_local_requests(CaSync *s, uint64_t *ret) {
         uint64_t sum;
         size_t i;

--- a/src/casync.c
+++ b/src/casync.c
@@ -19,6 +19,7 @@
 #include "casync.h"
 #include "def.h"
 #include "realloc-buffer.h"
+#include "time-util.h"
 #include "util.h"
 
 /* #undef EINVAL */

--- a/src/casync.h
+++ b/src/casync.h
@@ -152,6 +152,7 @@ int ca_sync_get_hardlink_digest(CaSync *s, CaChunkID *ret);
 
 int ca_sync_get_seed_requests(CaSync *s, uint64_t *ret);
 int ca_sync_get_seed_request_bytes(CaSync *s, uint64_t *ret);
+int ca_sync_get_seed_seeding_time_nsec(CaSync *s, uint64_t *ret);
 int ca_sync_get_local_requests(CaSync *s, uint64_t *ret);
 int ca_sync_get_local_request_bytes(CaSync *s, uint64_t *ret);
 int ca_sync_get_remote_requests(CaSync *s, uint64_t *ret);

--- a/src/casync.h
+++ b/src/casync.h
@@ -159,6 +159,7 @@ int ca_sync_get_remote_requests(CaSync *s, uint64_t *ret);
 int ca_sync_get_remote_request_bytes(CaSync *s, uint64_t *ret);
 
 int ca_sync_get_decoding_time_nsec(CaSync *s, uint64_t *ret);
+int ca_sync_get_runtime_nsec(CaSync *s, uint64_t *ret);
 
 int ca_sync_current_cache_hits(CaSync *s, uint64_t *ret);
 int ca_sync_current_cache_misses(CaSync *s, uint64_t *ret);

--- a/src/casync.h
+++ b/src/casync.h
@@ -158,6 +158,8 @@ int ca_sync_get_local_request_bytes(CaSync *s, uint64_t *ret);
 int ca_sync_get_remote_requests(CaSync *s, uint64_t *ret);
 int ca_sync_get_remote_request_bytes(CaSync *s, uint64_t *ret);
 
+int ca_sync_get_decoding_time_nsec(CaSync *s, uint64_t *ret);
+
 int ca_sync_current_cache_hits(CaSync *s, uint64_t *ret);
 int ca_sync_current_cache_misses(CaSync *s, uint64_t *ret);
 int ca_sync_current_cache_invalidated(CaSync *s, uint64_t *ret);

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,6 +3,8 @@
 util_sources = files('''
         log.c
         log.h
+        time-util.c
+        time-util.h
         util.c
         util.h
 '''.split())

--- a/src/parse-util.c
+++ b/src/parse-util.c
@@ -9,6 +9,7 @@
 #include <string.h>
 
 #include "parse-util.h"
+#include "time-util.h"
 #include "util.h"
 
 int parse_size(const char *t, uint64_t *size) {

--- a/src/time-util.c
+++ b/src/time-util.c
@@ -3,10 +3,10 @@
 #include "util.h"
 #include "time-util.h"
 
-char *format_timespan(char *buf, size_t l, usec_t t, usec_t accuracy) {
+char *format_timespan(char *buf, size_t l, uint64_t t, uint64_t accuracy) {
         static const struct {
                 const char *suffix;
-                usec_t usec;
+                uint64_t usec;
         } table[] = {
                 { "y",     USEC_PER_YEAR   },
                 { "month", USEC_PER_MONTH  },
@@ -44,7 +44,7 @@ char *format_timespan(char *buf, size_t l, usec_t t, usec_t accuracy) {
                 int k = 0;
                 size_t n;
                 bool done = false;
-                usec_t a, b;
+                uint64_t a, b;
 
                 if (t <= 0)
                         break;
@@ -63,7 +63,7 @@ char *format_timespan(char *buf, size_t l, usec_t t, usec_t accuracy) {
 
                 /* Let's see if we should shows this in dot notation */
                 if (t < USEC_PER_MINUTE && b > 0) {
-                        usec_t cc;
+                        uint64_t cc;
                         signed char j;
 
                         j = 0;

--- a/src/time-util.c
+++ b/src/time-util.c
@@ -1,0 +1,114 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
+#include "util.h"
+#include "time-util.h"
+
+char *format_timespan(char *buf, size_t l, usec_t t, usec_t accuracy) {
+        static const struct {
+                const char *suffix;
+                usec_t usec;
+        } table[] = {
+                { "y",     USEC_PER_YEAR   },
+                { "month", USEC_PER_MONTH  },
+                { "w",     USEC_PER_WEEK   },
+                { "d",     USEC_PER_DAY    },
+                { "h",     USEC_PER_HOUR   },
+                { "min",   USEC_PER_MINUTE },
+                { "s",     USEC_PER_SEC    },
+                { "ms",    USEC_PER_MSEC   },
+                { "us",    1               },
+        };
+
+        size_t i;
+        char *p = buf;
+        bool something = false;
+
+        assert(buf);
+        assert(l > 0);
+
+        if (t == USEC_INFINITY) {
+                strncpy(p, "infinity", l-1);
+                p[l-1] = 0;
+                return p;
+        }
+
+        if (t <= 0) {
+                strncpy(p, "0", l-1);
+                p[l-1] = 0;
+                return p;
+        }
+
+        /* The result of this function can be parsed with parse_sec */
+
+        for (i = 0; i < ELEMENTSOF(table); i++) {
+                int k = 0;
+                size_t n;
+                bool done = false;
+                usec_t a, b;
+
+                if (t <= 0)
+                        break;
+
+                if (t < accuracy && something)
+                        break;
+
+                if (t < table[i].usec)
+                        continue;
+
+                if (l <= 1)
+                        break;
+
+                a = t / table[i].usec;
+                b = t % table[i].usec;
+
+                /* Let's see if we should shows this in dot notation */
+                if (t < USEC_PER_MINUTE && b > 0) {
+                        usec_t cc;
+                        signed char j;
+
+                        j = 0;
+                        for (cc = table[i].usec; cc > 1; cc /= 10)
+                                j++;
+
+                        for (cc = accuracy; cc > 1; cc /= 10) {
+                                b /= 10;
+                                j--;
+                        }
+
+                        if (j > 0) {
+                                k = snprintf(p, l,
+                                             "%s"USEC_FMT".%0*"PRI_USEC"%s",
+                                             p > buf ? " " : "",
+                                             a,
+                                             j,
+                                             b,
+                                             table[i].suffix);
+
+                                t = 0;
+                                done = true;
+                        }
+                }
+
+                /* No? Then let's show it normally */
+                if (!done) {
+                        k = snprintf(p, l,
+                                     "%s"USEC_FMT"%s",
+                                     p > buf ? " " : "",
+                                     a,
+                                     table[i].suffix);
+
+                        t = b;
+                }
+
+                n = MIN((size_t) k, l);
+
+                l -= n;
+                p += n;
+
+                something = true;
+        }
+
+        *p = 0;
+
+        return buf;
+}

--- a/src/time-util.c
+++ b/src/time-util.c
@@ -6,17 +6,18 @@
 char *format_timespan(char *buf, size_t l, uint64_t t, uint64_t accuracy) {
         static const struct {
                 const char *suffix;
-                uint64_t usec;
+                uint64_t nsec;
         } table[] = {
-                { "y",     USEC_PER_YEAR   },
-                { "month", USEC_PER_MONTH  },
-                { "w",     USEC_PER_WEEK   },
-                { "d",     USEC_PER_DAY    },
-                { "h",     USEC_PER_HOUR   },
-                { "min",   USEC_PER_MINUTE },
-                { "s",     USEC_PER_SEC    },
-                { "ms",    USEC_PER_MSEC   },
-                { "us",    1               },
+                { "y",     NSEC_PER_YEAR   },
+                { "month", NSEC_PER_MONTH  },
+                { "w",     NSEC_PER_WEEK   },
+                { "d",     NSEC_PER_DAY    },
+                { "h",     NSEC_PER_HOUR   },
+                { "min",   NSEC_PER_MINUTE },
+                { "s",     NSEC_PER_SEC    },
+                { "ms",    NSEC_PER_MSEC   },
+                { "us",    NSEC_PER_USEC   },
+                { "ns",    1               },
         };
 
         size_t i;
@@ -26,7 +27,7 @@ char *format_timespan(char *buf, size_t l, uint64_t t, uint64_t accuracy) {
         assert(buf);
         assert(l > 0);
 
-        if (t == USEC_INFINITY) {
+        if (t == NSEC_INFINITY) {
                 strncpy(p, "infinity", l-1);
                 p[l-1] = 0;
                 return p;
@@ -52,22 +53,22 @@ char *format_timespan(char *buf, size_t l, uint64_t t, uint64_t accuracy) {
                 if (t < accuracy && something)
                         break;
 
-                if (t < table[i].usec)
+                if (t < table[i].nsec)
                         continue;
 
                 if (l <= 1)
                         break;
 
-                a = t / table[i].usec;
-                b = t % table[i].usec;
+                a = t / table[i].nsec;
+                b = t % table[i].nsec;
 
                 /* Let's see if we should shows this in dot notation */
-                if (t < USEC_PER_MINUTE && b > 0) {
+                if (t < NSEC_PER_MINUTE && b > 0) {
                         uint64_t cc;
                         signed char j;
 
                         j = 0;
-                        for (cc = table[i].usec; cc > 1; cc /= 10)
+                        for (cc = table[i].nsec; cc > 1; cc /= 10)
                                 j++;
 
                         for (cc = accuracy; cc > 1; cc /= 10) {

--- a/src/time-util.c
+++ b/src/time-util.c
@@ -77,7 +77,7 @@ char *format_timespan(char *buf, size_t l, uint64_t t, uint64_t accuracy) {
 
                         if (j > 0) {
                                 k = snprintf(p, l,
-                                             "%s"USEC_FMT".%0*"PRI_USEC"%s",
+                                             "%s%" PRIu64 ".%0*" PRIu64 "%s",
                                              p > buf ? " " : "",
                                              a,
                                              j,
@@ -92,7 +92,7 @@ char *format_timespan(char *buf, size_t l, uint64_t t, uint64_t accuracy) {
                 /* No? Then let's show it normally */
                 if (!done) {
                         k = snprintf(p, l,
-                                     "%s"USEC_FMT"%s",
+                                     "%s%" PRIu64 "%s",
                                      p > buf ? " " : "",
                                      a,
                                      table[i].suffix);

--- a/src/time-util.h
+++ b/src/time-util.h
@@ -3,9 +3,12 @@
 #ifndef footimeutilfoo
 #define footimeutilfoo
 
+#include <stdint.h>
+#include <time.h>
+
 #define NSEC_INFINITY ((uint64_t) -1)
 
-//#define NSEC_PER_SEC  ((uint64_t) UINT64_C(1000000000)) already defined in util.h
+#define NSEC_PER_SEC  ((uint64_t) UINT64_C(1000000000))
 #define NSEC_PER_MSEC ((uint64_t) UINT64_C(1000000))
 #define NSEC_PER_USEC ((uint64_t) UINT64_C(1000))
 
@@ -15,6 +18,42 @@
 #define NSEC_PER_WEEK ((uint64_t) (UINT64_C(7)*NSEC_PER_DAY))
 #define NSEC_PER_MONTH ((uint64_t) (UINT64_C(2629800)*NSEC_PER_SEC))
 #define NSEC_PER_YEAR ((uint64_t) (UINT64_C(31557600)*NSEC_PER_SEC))
+
+static inline uint64_t timespec_to_nsec(struct timespec t) {
+
+        if (t.tv_sec == (time_t) -1 &&
+            t.tv_nsec == (long) -1)
+                return UINT64_MAX;
+
+        return (uint64_t) t.tv_sec * UINT64_C(1000000000) + (uint64_t) t.tv_nsec;
+}
+
+static inline struct timespec nsec_to_timespec(uint64_t u) {
+
+        if (u == UINT64_MAX)
+                return (struct timespec) {
+                        .tv_sec = (time_t) -1,
+                        .tv_nsec = (long) -1,
+                };
+
+        return (struct timespec) {
+                .tv_sec = u / UINT64_C(1000000000),
+                .tv_nsec = u % UINT64_C(1000000000)
+        };
+}
+
+#define NSEC_TO_TIMESPEC_INIT(u) \
+        { .tv_sec = u == UINT64_MAX ? (time_t) -1 : (time_t) (u / UINT64_C(1000000000)), \
+          .tv_nsec = u == UINT64_MAX ? (long) -1 : (long) (u % UINT64_C(1000000000)) }
+
+static inline uint64_t now(clockid_t id) {
+        struct timespec ts;
+
+        if (clock_gettime(id, &ts) < 0)
+                return UINT64_MAX;
+
+        return timespec_to_nsec(ts);
+}
 
 char *format_timespan(char *buf, size_t l, uint64_t t, uint64_t accuracy);
 

--- a/src/time-util.h
+++ b/src/time-util.h
@@ -3,37 +3,34 @@
 #ifndef footimeutilfoo
 #define footimeutilfoo
 
-typedef uint64_t usec_t;
-typedef uint64_t nsec_t;
-
 #define PRI_NSEC PRIu64
 #define PRI_USEC PRIu64
 #define NSEC_FMT "%" PRI_NSEC
 #define USEC_FMT "%" PRI_USEC
 
-#define USEC_INFINITY ((usec_t) -1)
-#define NSEC_INFINITY ((nsec_t) -1)
+#define USEC_INFINITY ((uint64_t) -1)
+#define NSEC_INFINITY ((uint64_t) -1)
 
 #define MSEC_PER_SEC  1000ULL
-#define USEC_PER_SEC  ((usec_t) 1000000ULL)
-#define USEC_PER_MSEC ((usec_t) 1000ULL)
-//#define NSEC_PER_SEC  ((nsec_t) 1000000000ULL) already defined in util.h
-#define NSEC_PER_MSEC ((nsec_t) 1000000ULL)
-#define NSEC_PER_USEC ((nsec_t) 1000ULL)
+#define USEC_PER_SEC  ((uint64_t) 1000000ULL)
+#define USEC_PER_MSEC ((uint64_t) 1000ULL)
+//#define NSEC_PER_SEC  ((uint64_t) 1000000000ULL) already defined in util.h
+#define NSEC_PER_MSEC ((uint64_t) 1000000ULL)
+#define NSEC_PER_USEC ((uint64_t) 1000ULL)
 
-#define USEC_PER_MINUTE ((usec_t) (60ULL*USEC_PER_SEC))
-#define NSEC_PER_MINUTE ((nsec_t) (60ULL*NSEC_PER_SEC))
-#define USEC_PER_HOUR ((usec_t) (60ULL*USEC_PER_MINUTE))
-#define NSEC_PER_HOUR ((nsec_t) (60ULL*NSEC_PER_MINUTE))
-#define USEC_PER_DAY ((usec_t) (24ULL*USEC_PER_HOUR))
-#define NSEC_PER_DAY ((nsec_t) (24ULL*NSEC_PER_HOUR))
-#define USEC_PER_WEEK ((usec_t) (7ULL*USEC_PER_DAY))
-#define NSEC_PER_WEEK ((nsec_t) (7ULL*NSEC_PER_DAY))
-#define USEC_PER_MONTH ((usec_t) (2629800ULL*USEC_PER_SEC))
-#define NSEC_PER_MONTH ((nsec_t) (2629800ULL*NSEC_PER_SEC))
-#define USEC_PER_YEAR ((usec_t) (31557600ULL*USEC_PER_SEC))
-#define NSEC_PER_YEAR ((nsec_t) (31557600ULL*NSEC_PER_SEC))
+#define USEC_PER_MINUTE ((uint64_t) (60ULL*USEC_PER_SEC))
+#define NSEC_PER_MINUTE ((uint64_t) (60ULL*NSEC_PER_SEC))
+#define USEC_PER_HOUR ((uint64_t) (60ULL*USEC_PER_MINUTE))
+#define NSEC_PER_HOUR ((uint64_t) (60ULL*NSEC_PER_MINUTE))
+#define USEC_PER_DAY ((uint64_t) (24ULL*USEC_PER_HOUR))
+#define NSEC_PER_DAY ((uint64_t) (24ULL*NSEC_PER_HOUR))
+#define USEC_PER_WEEK ((uint64_t) (7ULL*USEC_PER_DAY))
+#define NSEC_PER_WEEK ((uint64_t) (7ULL*NSEC_PER_DAY))
+#define USEC_PER_MONTH ((uint64_t) (2629800ULL*USEC_PER_SEC))
+#define NSEC_PER_MONTH ((uint64_t) (2629800ULL*NSEC_PER_SEC))
+#define USEC_PER_YEAR ((uint64_t) (31557600ULL*USEC_PER_SEC))
+#define NSEC_PER_YEAR ((uint64_t) (31557600ULL*NSEC_PER_SEC))
 
-char *format_timespan(char *buf, size_t l, usec_t t, usec_t accuracy);
+char *format_timespan(char *buf, size_t l, uint64_t t, uint64_t accuracy);
 
 #endif

--- a/src/time-util.h
+++ b/src/time-util.h
@@ -3,27 +3,17 @@
 #ifndef footimeutilfoo
 #define footimeutilfoo
 
-#define USEC_INFINITY ((uint64_t) -1)
 #define NSEC_INFINITY ((uint64_t) -1)
 
-#define MSEC_PER_SEC  1000ULL
-#define USEC_PER_SEC  ((uint64_t) 1000000ULL)
-#define USEC_PER_MSEC ((uint64_t) 1000ULL)
 //#define NSEC_PER_SEC  ((uint64_t) 1000000000ULL) already defined in util.h
 #define NSEC_PER_MSEC ((uint64_t) 1000000ULL)
 #define NSEC_PER_USEC ((uint64_t) 1000ULL)
 
-#define USEC_PER_MINUTE ((uint64_t) (60ULL*USEC_PER_SEC))
 #define NSEC_PER_MINUTE ((uint64_t) (60ULL*NSEC_PER_SEC))
-#define USEC_PER_HOUR ((uint64_t) (60ULL*USEC_PER_MINUTE))
 #define NSEC_PER_HOUR ((uint64_t) (60ULL*NSEC_PER_MINUTE))
-#define USEC_PER_DAY ((uint64_t) (24ULL*USEC_PER_HOUR))
 #define NSEC_PER_DAY ((uint64_t) (24ULL*NSEC_PER_HOUR))
-#define USEC_PER_WEEK ((uint64_t) (7ULL*USEC_PER_DAY))
 #define NSEC_PER_WEEK ((uint64_t) (7ULL*NSEC_PER_DAY))
-#define USEC_PER_MONTH ((uint64_t) (2629800ULL*USEC_PER_SEC))
 #define NSEC_PER_MONTH ((uint64_t) (2629800ULL*NSEC_PER_SEC))
-#define USEC_PER_YEAR ((uint64_t) (31557600ULL*USEC_PER_SEC))
 #define NSEC_PER_YEAR ((uint64_t) (31557600ULL*NSEC_PER_SEC))
 
 char *format_timespan(char *buf, size_t l, uint64_t t, uint64_t accuracy);

--- a/src/time-util.h
+++ b/src/time-util.h
@@ -3,11 +3,6 @@
 #ifndef footimeutilfoo
 #define footimeutilfoo
 
-#define PRI_NSEC PRIu64
-#define PRI_USEC PRIu64
-#define NSEC_FMT "%" PRI_NSEC
-#define USEC_FMT "%" PRI_USEC
-
 #define USEC_INFINITY ((uint64_t) -1)
 #define NSEC_INFINITY ((uint64_t) -1)
 

--- a/src/time-util.h
+++ b/src/time-util.h
@@ -5,16 +5,16 @@
 
 #define NSEC_INFINITY ((uint64_t) -1)
 
-//#define NSEC_PER_SEC  ((uint64_t) 1000000000ULL) already defined in util.h
-#define NSEC_PER_MSEC ((uint64_t) 1000000ULL)
-#define NSEC_PER_USEC ((uint64_t) 1000ULL)
+//#define NSEC_PER_SEC  ((uint64_t) UINT64_C(1000000000)) already defined in util.h
+#define NSEC_PER_MSEC ((uint64_t) UINT64_C(1000000))
+#define NSEC_PER_USEC ((uint64_t) UINT64_C(1000))
 
-#define NSEC_PER_MINUTE ((uint64_t) (60ULL*NSEC_PER_SEC))
-#define NSEC_PER_HOUR ((uint64_t) (60ULL*NSEC_PER_MINUTE))
-#define NSEC_PER_DAY ((uint64_t) (24ULL*NSEC_PER_HOUR))
-#define NSEC_PER_WEEK ((uint64_t) (7ULL*NSEC_PER_DAY))
-#define NSEC_PER_MONTH ((uint64_t) (2629800ULL*NSEC_PER_SEC))
-#define NSEC_PER_YEAR ((uint64_t) (31557600ULL*NSEC_PER_SEC))
+#define NSEC_PER_MINUTE ((uint64_t) (UINT64_C(60)*NSEC_PER_SEC))
+#define NSEC_PER_HOUR ((uint64_t) (UINT64_C(60)*NSEC_PER_MINUTE))
+#define NSEC_PER_DAY ((uint64_t) (UINT64_C(24)*NSEC_PER_HOUR))
+#define NSEC_PER_WEEK ((uint64_t) (UINT64_C(7)*NSEC_PER_DAY))
+#define NSEC_PER_MONTH ((uint64_t) (UINT64_C(2629800)*NSEC_PER_SEC))
+#define NSEC_PER_YEAR ((uint64_t) (UINT64_C(31557600)*NSEC_PER_SEC))
 
 char *format_timespan(char *buf, size_t l, uint64_t t, uint64_t accuracy);
 

--- a/src/time-util.h
+++ b/src/time-util.h
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: LGPL-2.1+ */
+
+#ifndef footimeutilfoo
+#define footimeutilfoo
+
+typedef uint64_t usec_t;
+typedef uint64_t nsec_t;
+
+#define PRI_NSEC PRIu64
+#define PRI_USEC PRIu64
+#define NSEC_FMT "%" PRI_NSEC
+#define USEC_FMT "%" PRI_USEC
+
+#define USEC_INFINITY ((usec_t) -1)
+#define NSEC_INFINITY ((nsec_t) -1)
+
+#define MSEC_PER_SEC  1000ULL
+#define USEC_PER_SEC  ((usec_t) 1000000ULL)
+#define USEC_PER_MSEC ((usec_t) 1000ULL)
+//#define NSEC_PER_SEC  ((nsec_t) 1000000000ULL) already defined in util.h
+#define NSEC_PER_MSEC ((nsec_t) 1000000ULL)
+#define NSEC_PER_USEC ((nsec_t) 1000ULL)
+
+#define USEC_PER_MINUTE ((usec_t) (60ULL*USEC_PER_SEC))
+#define NSEC_PER_MINUTE ((nsec_t) (60ULL*NSEC_PER_SEC))
+#define USEC_PER_HOUR ((usec_t) (60ULL*USEC_PER_MINUTE))
+#define NSEC_PER_HOUR ((nsec_t) (60ULL*NSEC_PER_MINUTE))
+#define USEC_PER_DAY ((usec_t) (24ULL*USEC_PER_HOUR))
+#define NSEC_PER_DAY ((nsec_t) (24ULL*NSEC_PER_HOUR))
+#define USEC_PER_WEEK ((usec_t) (7ULL*USEC_PER_DAY))
+#define NSEC_PER_WEEK ((nsec_t) (7ULL*NSEC_PER_DAY))
+#define USEC_PER_MONTH ((usec_t) (2629800ULL*USEC_PER_SEC))
+#define NSEC_PER_MONTH ((nsec_t) (2629800ULL*NSEC_PER_SEC))
+#define USEC_PER_YEAR ((usec_t) (31557600ULL*USEC_PER_SEC))
+#define NSEC_PER_YEAR ((nsec_t) (31557600ULL*NSEC_PER_SEC))
+
+char *format_timespan(char *buf, size_t l, usec_t t, usec_t accuracy);
+
+#endif

--- a/src/util.c
+++ b/src/util.c
@@ -22,6 +22,7 @@
 #undef basename
 
 #include "def.h"
+#include "time-util.h"
 #include "util.h"
 
 #define HOLE_MIN 4096

--- a/src/util.h
+++ b/src/util.h
@@ -14,7 +14,6 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/vfs.h>
-#include <time.h>
 #include <unistd.h>
 
 #include <linux/btrfs.h>
@@ -65,42 +64,6 @@
                 (void)0))
 
 
-
-static inline uint64_t timespec_to_nsec(struct timespec t) {
-
-        if (t.tv_sec == (time_t) -1 &&
-            t.tv_nsec == (long) -1)
-                return UINT64_MAX;
-
-        return (uint64_t) t.tv_sec * UINT64_C(1000000000) + (uint64_t) t.tv_nsec;
-}
-
-static inline struct timespec nsec_to_timespec(uint64_t u) {
-
-        if (u == UINT64_MAX)
-                return (struct timespec) {
-                        .tv_sec = (time_t) -1,
-                        .tv_nsec = (long) -1,
-                };
-
-        return (struct timespec) {
-                .tv_sec = u / UINT64_C(1000000000),
-                .tv_nsec = u % UINT64_C(1000000000)
-        };
-}
-
-#define NSEC_TO_TIMESPEC_INIT(u) \
-        { .tv_sec = u == UINT64_MAX ? (time_t) -1 : (time_t) (u / UINT64_C(1000000000)), \
-          .tv_nsec = u == UINT64_MAX ? (long) -1 : (long) (u % UINT64_C(1000000000)) }
-
-static inline uint64_t now(clockid_t id) {
-        struct timespec ts;
-
-        if (clock_gettime(id, &ts) < 0)
-                return UINT64_MAX;
-
-        return timespec_to_nsec(ts);
-}
 
 int loop_write(int fd, const void *p, size_t l);
 int loop_write_block(int fd, const void *p, size_t l);
@@ -768,8 +731,6 @@ struct fsxattr {
 #define FS_IOC_FSGETXATTR _IOR ('X', 31, struct fsxattr)
 #define FS_IOC_FSSETXATTR _IOW ('X', 32, struct fsxattr)
 #endif
-
-#define NSEC_PER_SEC (UINT64_C(1000000000))
 
 /* Cleanup functions */
 

--- a/test/notify-wait.c
+++ b/test/notify-wait.c
@@ -8,6 +8,7 @@
 #include <sys/un.h>
 #include <sys/wait.h>
 
+#include "time-util.h"
 #include "util.h"
 
 #define TIMEOUT_NSEC UINT64_C(30000000000)

--- a/test/test-cachunker-histogram.c
+++ b/test/test-cachunker-histogram.c
@@ -5,6 +5,7 @@
 #include <pthread.h>
 #include <stdio.h>
 
+#include "time-util.h"
 #include "util.h"
 #include "cachunker.h"
 

--- a/test/test-cadigest.c
+++ b/test/test-cadigest.c
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: LGPL-2.1+ */
 
+#include "time-util.h"
 #include "util.h"
 #include "cadigest.h"
 

--- a/test/test-calocation.c
+++ b/test/test-calocation.c
@@ -4,6 +4,7 @@
 #include "cadigest.h"
 #include "calocation.h"
 #include "def.h"
+#include "time-util.h"
 #include "util.h"
 #include "caformat.h"
 


### PR DESCRIPTION
This MR adds the following lines to `casync extract` verbose output:

    Time spent seeding: 6.529038 secs (9%)
    Time spent decoding: 63.074518 secs (90%)
    Total extract time: 69.623602 secs (00:01:10)

----

Here are a few comments:

- time measurements are done with `now()`, which provides nanoseconds precision. However in the output I round to micro-seconds, as I think displaying nanoseconds is overkill.
- I used the words `seeding` and `decoding` to describe the two main steps of `casync extract`. "Seeding" was obvious. "Decoding" seems a good word to me, but feel free to propose something else.