### PR TITLE
ca_chunk_file_test: check compressed file before uncompressed one

### DIFF
--- a/src/cachunk.c
+++ b/src/cachunk.c
@@ -731,11 +731,11 @@ int ca_chunk_file_test(int chunk_fd, const char *prefix, const CaChunkID *chunki
         if (!chunkid)
                 return -EINVAL;
 
-        r = ca_chunk_file_access(chunk_fd, prefix, chunkid, NULL);
+        r = ca_chunk_file_access(chunk_fd, prefix, chunkid, ca_compressed_chunk_suffix());
         if (r != 0)
                 return r;
 
-        return ca_chunk_file_access(chunk_fd, prefix, chunkid, ca_compressed_chunk_suffix());
+        return ca_chunk_file_access(chunk_fd, prefix, chunkid, NULL);
 }
 
 int ca_chunk_file_remove(int chunk_fd, const char *prefix, const CaChunkID *chunkid) {


### PR DESCRIPTION
As compression is always enabled, we are more likely to find a compressed chunk in the repo than an uncompressed one.

(just for performance)