### PR TITLE
[WIP] casync: reuse seed cache for multiple checkouts

### DIFF
--- a/doc/casync.rst
+++ b/doc/casync.rst
@@ -161,6 +161,7 @@ General options:
 --digest=<DIGEST>               Pick digest algorithm (sha512-256 or sha256)
 --compression=<COMPRESSION>     Pick compression algorithm (zstd, xz or gzip)
 --seed=<PATH>                   Additional file or directory to use as seed
+--seed-cache=<PATH>             Directory to use as seed cache
 --cache=<PATH>                  Directory to use as encoder cache
 --cache-auto, -c                Pick encoder cache directory automatically
 --rate-limit-bps=<LIMIT>        Maximum bandwidth in bytes/s for remote communication

--- a/src/caencoder.c
+++ b/src/caencoder.c
@@ -3634,11 +3634,13 @@ static int ca_encoder_seek_path(CaEncoder *e, const char *path) {
                 size_t l = strcspn(path, "/");
                 char name[l + 1];
 
-                if (l <= 0)
-                        return -EINVAL;
-
                 if (!S_ISDIR(node->stat.st_mode))
                         return -ENOTDIR;
+
+                if (l == 0) {
+                        path++;
+                        continue;
+                }
 
                 memcpy(name, path, l);
                 name[l] = 0;
@@ -3651,6 +3653,8 @@ static int ca_encoder_seek_path(CaEncoder *e, const char *path) {
                 if (*path == 0)
                         break;
                 path++;
+                if(*path == 0)
+                        break;
 
                 r = ca_encoder_enter_child(e);
                 if (r < 0)
@@ -3702,8 +3706,7 @@ static int ca_encoder_node_install_name_table(CaEncoder *e, CaEncoderNode *node,
 
                 t = t->parent;
                 if (!t) {
-                        log_debug("Name table chain ended prematurely.");
-                        return -ESPIPE;
+                        return 0;
                 }
         }
 

--- a/src/caremote.c
+++ b/src/caremote.c
@@ -376,12 +376,6 @@ static int ca_remote_url_prefix_install(CaRemote *rr, const char *url) {
         assert(rr);
         assert(url);
 
-        /* Explicitly mask out / and ./ as indicators for local directories */
-        if (url[0] == '/')
-                return -EINVAL;
-        if (url[0] == '.' && url[1] == '/')
-                return -EINVAL;
-
         if (!strchr(URL_PROTOCOL_FIRST, url[0]))
                 return -EINVAL;
 
@@ -429,12 +423,6 @@ static int ca_remote_ssh_prefix_install(CaRemote *rr, const char *url) {
 
         assert(rr);
         assert(url);
-
-        /* Explicitly mask out / and ./ as indicators for local directories */
-        if (url[0] == '/')
-                return -EINVAL;
-        if (url[0] == '.' && url[1] == '/')
-                return -EINVAL;
 
         n = strspn(url, HOSTNAME_CHARSET);
         if (n <= 0)

--- a/src/caseed.c
+++ b/src/caseed.c
@@ -32,6 +32,8 @@ struct CaSeed {
         int cache_fd;
         char *cache_path;
 
+        char *base_path;
+
         CaChunker chunker;
         CaDigest *chunk_digest;
 
@@ -102,6 +104,7 @@ CaSeed *ca_seed_unref(CaSeed *s) {
         safe_close(s->base_fd);
         safe_close(s->cache_fd);
         free(s->cache_path);
+        free(s->base_path);
 
         ca_digest_free(s->chunk_digest);
 
@@ -139,6 +142,9 @@ int ca_seed_set_base_path(CaSeed *s, const char *path) {
         if (s->base_fd < 0)
                 return -errno;
 
+        s->base_path = strdup(path);
+        if (!s->base_path)
+                return -errno;
         return 0;
 }
 
@@ -250,6 +256,7 @@ static int ca_seed_make_chunk_id(CaSeed *s, const void *p, size_t l, CaChunkID *
 static int ca_seed_write_cache_entry(CaSeed *s, CaLocation *location, const void *data, size_t l) {
         char ids[CA_CHUNK_ID_FORMAT_MAX];
         const char *t, *four, *combined;
+        CaFileRoot *root;
         CaChunkID id;
         int r;
 
@@ -258,7 +265,15 @@ static int ca_seed_write_cache_entry(CaSeed *s, CaLocation *location, const void
         assert(data);
         assert(l > 0);
 
+        r = ca_seed_get_file_root(s, &root);
+        if (r < 0)
+                return r;
+
         r = ca_location_patch_size(&location, l);
+        if (r < 0)
+                return r;
+
+        r = ca_location_patch_root(&location, root);
         if (r < 0)
                 return r;
 
@@ -872,7 +887,7 @@ int ca_seed_get_file_root(CaSeed *s, CaFileRoot **ret) {
                 } else
                         return -EUNATCH;
 
-                r = ca_file_root_new(NULL, base_fd, &s->root);
+                r = ca_file_root_new(s->base_path, base_fd, &s->root);
                 if (r < 0)
                         return r;
         }

--- a/src/caseed.c
+++ b/src/caseed.c
@@ -41,6 +41,7 @@ struct CaSeed {
         bool remove_cache:1;
         bool cache_hardlink:1;
         bool cache_chunks:1;
+        bool cache_only:1;
 
         ReallocBuffer buffer;
         CaLocation *buffer_location;
@@ -480,6 +481,17 @@ finish:
         return r;
 }
 
+int ca_seed_set_cache_only(CaSeed *s, bool cache_only) {
+        if (!s)
+                return -EINVAL;
+        if (s->ready && !cache_only)
+                return -EINVAL;
+
+        s->cache_only = cache_only;
+
+        return 0;
+}
+
 int ca_seed_step(CaSeed *s) {
         int r;
 
@@ -503,6 +515,11 @@ int ca_seed_step(CaSeed *s) {
         r = ca_seed_open(s);
         if (r < 0)
                 return r;
+
+        if (s->cache_only) {
+                s->ready = true;
+                return CA_SEED_READY;
+        }
 
         for (;;) {
                 int step;

--- a/src/caseed.h
+++ b/src/caseed.h
@@ -38,6 +38,8 @@ int ca_seed_current_mode(CaSeed *seed, mode_t *ret);
 
 int ca_seed_set_feature_flags(CaSeed *s, uint64_t flags);
 
+int ca_seed_set_cache_only(CaSeed *s, bool cache_only);
+
 int ca_seed_set_chunk_size(CaSeed *s, size_t cmin, size_t cavg, size_t cmax);
 
 int ca_seed_set_hardlink(CaSeed *s, bool b);

--- a/src/caseed.h
+++ b/src/caseed.h
@@ -36,6 +36,8 @@ int ca_seed_get_hardlink_target(CaSeed *s, const CaChunkID *id, char **ret);
 int ca_seed_current_path(CaSeed *seed, char **ret);
 int ca_seed_current_mode(CaSeed *seed, mode_t *ret);
 
+int ca_seed_write_absolute_cache_paths(CaSeed *s, bool abs);
+
 int ca_seed_set_feature_flags(CaSeed *s, uint64_t flags);
 
 int ca_seed_set_cache_only(CaSeed *s, bool cache_only);

--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -1623,6 +1623,12 @@ static int verb_extract(int argc, char *argv[]) {
         if (!s)
                 return log_oom();
 
+        if (arg_cache) {
+                r = ca_sync_set_cache_path(s, arg_cache);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to set cache: %m");
+        }
+
         if (arg_dry_run) {
                 r = ca_sync_decode_set_dry_run(s, arg_dry_run);
                 if (r < 0)

--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -1616,6 +1616,12 @@ static int verb_extract(int argc, char *argv[]) {
         if (!s)
                 return log_oom();
 
+        if (arg_dry_run) {
+                r = ca_sync_decode_set_dry_run(s, arg_dry_run);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to set decode dry_run: %m");
+        }
+
         if (IN_SET(operation, EXTRACT_ARCHIVE_INDEX, EXTRACT_BLOB_INDEX)) {
                 r = set_default_store(input);
                 if (r < 0)

--- a/src/casync.c
+++ b/src/casync.c
@@ -138,6 +138,7 @@ struct CaSync {
         bool archive_digest:1;
         bool hardlink_digest:1;
         bool payload_digest:1;
+        bool decode_dry_run:1;
 
         CaFileRoot *archive_root;
 
@@ -1825,6 +1826,15 @@ static int ca_sync_write_remote_archive_eof(CaSync *s) {
         return ca_remote_put_archive_eof(s->remote_archive);
 }
 
+int ca_sync_decode_set_dry_run(CaSync *s, bool dry_run) {
+        if (!s)
+                return -EINVAL;
+
+        s->decode_dry_run = dry_run;
+
+        return 0;
+}
+
 static int ca_sync_cache_get(CaSync *s, CaLocation *location) {
         int r;
 
@@ -2617,6 +2627,9 @@ static int ca_sync_step_decode(CaSync *s) {
 
         if (s->archive_eof)
                 return -EPIPE;
+
+        if (s->decode_dry_run)
+                return CA_SYNC_FINISHED;
 
         step = ca_decoder_step(s->decoder);
         if (step < 0)

--- a/src/casync.c
+++ b/src/casync.c
@@ -1180,7 +1180,7 @@ int ca_sync_add_seed_fd(CaSync *s, int fd) {
         return 0;
 }
 
-int ca_sync_add_seed_path(CaSync *s, const char *path) {
+int ca_sync_add_seed_path(CaSync *s, const char *path, const char *cache) {
         CaSeed *seed;
         int r;
 
@@ -1201,6 +1201,14 @@ int ca_sync_add_seed_path(CaSync *s, const char *path) {
         if (r < 0) {
                 ca_seed_unref(seed);
                 return r;
+        }
+
+        if (cache) {
+                r = ca_seed_set_cache_path(seed, cache);
+                if (r < 0) {
+                        ca_seed_unref(seed);
+                        return r;
+                }
         }
 
         s->seeds[s->n_seeds++] = seed;

--- a/src/casync.h
+++ b/src/casync.h
@@ -86,7 +86,7 @@ int ca_sync_add_store_auto(CaSync *sync, const char *locator);
 
 /* Additional seeds to use */
 int ca_sync_add_seed_fd(CaSync *sync, int fd);
-int ca_sync_add_seed_path(CaSync *sync, const char *path);
+int ca_sync_add_seed_path(CaSync *sync, const char *path, const char *cache);
 
 /* Path to use as cache */
 int ca_sync_set_cache_fd(CaSync *sync, int fd);

--- a/src/casync.h
+++ b/src/casync.h
@@ -166,4 +166,6 @@ int ca_sync_current_cache_misses(CaSync *s, uint64_t *ret);
 int ca_sync_current_cache_invalidated(CaSync *s, uint64_t *ret);
 int ca_sync_current_cache_added(CaSync *s, uint64_t *ret);
 
+int ca_sync_decode_set_dry_run(CaSync *s, bool dry_run);
+
 #endif

--- a/src/casync.h
+++ b/src/casync.h
@@ -85,8 +85,14 @@ int ca_sync_add_store_remote(CaSync *sync, const char *url);
 int ca_sync_add_store_auto(CaSync *sync, const char *locator);
 
 /* Additional seeds to use */
+typedef enum CaSyncSeedOptions {
+        CA_SYNC_SEED_CACHE_ONLY         = 1U << 0,
+        CA_SYNC_SEED_ABSOLUTE_SEED_PATH = 1U << 1,
+} CaSyncSeedOptions;
+
 int ca_sync_add_seed_fd(CaSync *sync, int fd);
 int ca_sync_add_seed_path(CaSync *sync, const char *path, const char *cache);
+int ca_sync_add_seed_path_options(CaSync *sync, const char *path, const char *cache, CaSyncSeedOptions options);
 
 /* Path to use as cache */
 int ca_sync_set_cache_fd(CaSync *sync, int fd);


### PR DESCRIPTION
it allows to reuse a seed cache among different checkouts.

It enables this use case:

```
# The cache is empty, we retrieve all the chunks from the store
$ casync extract --seed-cache cache  --cache cache \
   --store=http://localhost:8000/default.castr  --seed-output=no i.caidx checkout_1

# We have created a checkout, fill the seed-cache
$ casync extract --seed-cache $(pwd)/cache  --cache $(pwd)/cache /default.castr \
 --dry-run --seed-output=yes  i.caidx t

# Now the seed cache is filled, we can reuse it without fetching any data from
# the remote store
$ casync extract --seed-cache cache  --cache cache \
  --seed-output=no i.caidx checkout_2
```

Closes: https://github.com/systemd/casync/issues/209