### PR TITLE
Fix uninitialized variable in log_fullv

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -72,7 +72,9 @@ static int log_fullv(
         if (level > get_log_level())
                 return -abs(error);
 
-        if (!endswith(format, "\n"))
+        if (endswith(format, "\n"))
+                fmt = format;
+        else
                 fmt = strjoina(format, "\n");
 
         if (error != 0)


### PR DESCRIPTION
If `format` already ends with `\n`, then `fmt` was not initialized, and used all the same. Funny that the compiler didn't catch it.