### PR TITLE
Fix usage for list and mtree commands

### DIFF
--- a/doc/casync.rst
+++ b/doc/casync.rst
@@ -13,7 +13,7 @@ Synopsis
 | **casync** [*OPTIONS*...] list [*ARCHIVE* | *ARCHIVE_INDEX* | *DIRECTORY*] [*PATH*]
 | **casync** [*OPTIONS*...] mtree [*ARCHIVE* | *ARCHIVE_INDEX* | *DIRECTORY*] [*PATH*]
 | **casync** [*OPTIONS*...] stat [*ARCHIVE* | *ARCHIVE_INDEX* | *DIRECTORY*] [*PATH*]
-| **casync** [*OPTIONS*...] digest [*ARCHIVE* | *BLOB* | *ARCHIVE_INDEX* | *BLOB_INDEX* | *DIRECTORY*]
+| **casync** [*OPTIONS*...] digest [*ARCHIVE* | *BLOB* | *ARCHIVE_INDEX* | *BLOB_INDEX* | *DIRECTORY*] [PATH]
 | **casync** [*OPTIONS*...] mount [*ARCHIVE* | *ARCHIVE_INDEX*] *PATH*
 | **casync** [*OPTIONS*...] mkdev [*BLOB* | *BLOB_INDEX*] [*NODE*]
 | **casync** [*OPTIONS*...] gc *BLOB_INDEX* | *ARCHIVE_INDEX* ...
@@ -101,10 +101,15 @@ Example output::
      Group: zbyszek (1000)
 
 |
-| **casync** **digest** [*ARCHIVE* | *BLOB* | *ARCHIVE_INDEX* | *BLOB_INDEX* | *DIRECTORY*]
+| **casync** **digest** [*BLOB* | *BLOB_INDEX* | *DIRECTORY*]
+| **casync** **digest** *ARCHIVE* | *ARCHIVE_INDEX* [PATH]
 
-This will compute and print the checksum of the argument.
-The argument is optional and defaults to the current directory::
+This will compute and print the checksum of the file or directory, or the given
+*PATH* as found in either *ARCHIVE* or *ARCHIVE_INDEX*. Both arguments are
+optional. The first default to the current directory. The second defaults to
+the top-level path of the archive (``/``).
+
+Example::
 
   $ casync digest
   d1698b0c4c27163284abea5d1e369b92e89dd07cb74378638849800e0406baf7

--- a/doc/casync.rst
+++ b/doc/casync.rst
@@ -57,9 +57,10 @@ The metadata replayed from the archive is controlled by the ``--with-*`` and
 |
 | **casync** **list** [*ARCHIVE* | *ARCHIVE_INDEX* | *DIRECTORY*] [*PATH*]
 
-This will list all the files and directories in the specified .catar
-archive or .caidx index, or the directory. The argument is optional,
-and the current directory will be used by default.
+This will list all the files and directories at *PATH* as found in either
+*ARCHIVE* or *ARCHIVE_INDEX* or underneath *DIRECTORY*. Both arguments are
+optional. The first defaults to the current directory. The second defaults to
+the top-level path of the archive (``/``).
 
 The output includes the permission mask and file names::
 

--- a/doc/casync.rst
+++ b/doc/casync.rst
@@ -86,7 +86,7 @@ key=value format defined by BSD mtree(5)::
 This will show detailed information about a file or directory *PATH*, as found
 in either *ARCHIVE* or *ARCHIVE_INDEX* or underneath *DIRECTORY*. Both arguments
 are optional. The first defaults to the current directory, and the second
-the top-level path (``.``).
+the top-level path (``/``).
 
 Example output::
 

--- a/doc/casync.rst
+++ b/doc/casync.rst
@@ -29,7 +29,7 @@ Commands
 | **casync** **make** [*ARCHIVE* | *ARCHIVE_INDEX*] [*DIRECTORY*]
 | **casync** **make** [*BLOB_INDEX*] *FILE* | *DEVICE*
 
-This will create either a .catar archive or an .caidx index for for the given
+This will create either a .catar archive or an .caidx index for the given
 *DIRECTORY*, or a .caibx index for the given *FILE* or block *DEVICE*. The type
 of output is automatically chosen based on the file extension (this may be
 overridden with ``--what=``). *DIRECTORY* is optional, and the current directory

--- a/doc/casync.rst
+++ b/doc/casync.rst
@@ -10,8 +10,8 @@ Synopsis
 
 | **casync** [*OPTIONS*...] make [*ARCHIVE* | *ARCHIVE_INDEX* | *BLOB_INDEX*] [*PATH*]
 | **casync** [*OPTIONS*...] extract [*ARCHIVE* | *ARCHIVE_INDEX* | *BLOB_INDEX*] [*PATH*]
-| **casync** [*OPTIONS*...] list [*ARCHIVE* | *ARCHIVE_INDEX* | *DIRECTORY*]
-| **casync** [*OPTIONS*...] mtree [*ARCHIVE* | *ARCHIVE_INDEX* | *DIRECTORY*]
+| **casync** [*OPTIONS*...] list [*ARCHIVE* | *ARCHIVE_INDEX* | *DIRECTORY*] [*PATH*]
+| **casync** [*OPTIONS*...] mtree [*ARCHIVE* | *ARCHIVE_INDEX* | *DIRECTORY*] [*PATH*]
 | **casync** [*OPTIONS*...] stat [*ARCHIVE* | *ARCHIVE_INDEX* | *DIRECTORY*] [*PATH*]
 | **casync** [*OPTIONS*...] digest [*ARCHIVE* | *BLOB* | *ARCHIVE_INDEX* | *BLOB_INDEX* | *DIRECTORY*]
 | **casync** [*OPTIONS*...] mount [*ARCHIVE* | *ARCHIVE_INDEX*] *PATH*
@@ -55,7 +55,7 @@ The metadata replayed from the archive is controlled by the ``--with-*`` and
 ``--without-*`` options.
 
 |
-| **casync** **list** [*ARCHIVE* | *ARCHIVE_INDEX* | *DIRECTORY*]
+| **casync** **list** [*ARCHIVE* | *ARCHIVE_INDEX* | *DIRECTORY*] [*PATH*]
 
 This will list all the files and directories in the specified .catar
 archive or .caidx index, or the directory. The argument is optional,
@@ -69,7 +69,7 @@ The output includes the permission mask and file names::
   -rw-r--r-- TODO
 
 |
-| **casync** **mtree** [*ARCHIVE* | *ARCHIVE_INDEX* | *DIRECTORY*]
+| **casync** **mtree** [*ARCHIVE* | *ARCHIVE_INDEX* | *DIRECTORY*] [*PATH*]
 
 This is similar to **list**, but includes information about each entry in the
 key=value format defined by BSD mtree(5)::

--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -80,7 +80,7 @@ static void help(void) {
                "%1$s [OPTIONS...] list [ARCHIVE|ARCHIVE_INDEX|DIRECTORY] [PATH]\n"
                "%1$s [OPTIONS...] mtree [ARCHIVE|ARCHIVE_INDEX|DIRECTORY] [PATH]\n"
                "%1$s [OPTIONS...] stat [ARCHIVE|ARCHIVE_INDEX|DIRECTORY] [PATH]\n"
-               "%1$s [OPTIONS...] digest [ARCHIVE|BLOB|ARCHIVE_INDEX|BLOB_INDEX|DIRECTORY]\n"
+               "%1$s [OPTIONS...] digest [ARCHIVE|BLOB|ARCHIVE_INDEX|BLOB_INDEX|DIRECTORY] [PATH]\n"
 #if HAVE_FUSE
                "%1$s [OPTIONS...] mount [ARCHIVE|ARCHIVE_INDEX] PATH\n"
 #endif
@@ -2449,7 +2449,7 @@ static int verb_digest(int argc, char *argv[]) {
         else if (arg_what == WHAT_DIRECTORY)
                 operation = DIGEST_DIRECTORY;
         else if (arg_what != _WHAT_INVALID) {
-                log_error("\"make\" operation may only be combined with --what=archive, --what=blob, --what=archive-index, --what=blob-index or --what=directory.");
+                log_error("\"digest\" operation may only be combined with --what=archive, --what=blob, --what=archive-index, --what=blob-index or --what=directory.");
                 return -EINVAL;
         }
 

--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -77,8 +77,8 @@ static CaCompressionType arg_compression = CA_COMPRESSION_DEFAULT;
 static void help(void) {
         printf("%1$s [OPTIONS...] make [ARCHIVE|ARCHIVE_INDEX|BLOB_INDEX] [PATH]\n"
                "%1$s [OPTIONS...] extract [ARCHIVE|ARCHIVE_INDEX|BLOB_INDEX] [PATH]\n"
-               "%1$s [OPTIONS...] list [ARCHIVE|ARCHIVE_INDEX|DIRECTORY]\n"
-               "%1$s [OPTIONS...] mtree [ARCHIVE|ARCHIVE_INDEX|DIRECTORY]\n"
+               "%1$s [OPTIONS...] list [ARCHIVE|ARCHIVE_INDEX|DIRECTORY] [PATH]\n"
+               "%1$s [OPTIONS...] mtree [ARCHIVE|ARCHIVE_INDEX|DIRECTORY] [PATH]\n"
                "%1$s [OPTIONS...] stat [ARCHIVE|ARCHIVE_INDEX|DIRECTORY] [PATH]\n"
                "%1$s [OPTIONS...] digest [ARCHIVE|BLOB|ARCHIVE_INDEX|BLOB_INDEX|DIRECTORY]\n"
 #if HAVE_FUSE


### PR DESCRIPTION
While I was working on completing the bash completion script (see #215), I found out that both list and mtree commands have an incomplete usage.

Both handle a second optional argument *PATH*, as the stat command does.

Correct me if I am wrong.

---

The three commands list, mtree and stats are dispatched to the same
function: verb_list().

Thus, they share the same command line interface:

	casync list|mtree|stat [ARCHIVE|ARCHIVE_INDEX|DIRECTORY] [PATH]

However, in the end, the output is different.

This commit fixes the help usage and the man page for both commands list
and mtree.