### PR TITLE
Propagate log-level to protocol helpers

### DIFF
--- a/src/caremote.h
+++ b/src/caremote.h
@@ -50,6 +50,7 @@ int ca_remote_get_remote_feature_flags(CaRemote *rr, uint64_t* flags);
 int ca_remote_set_digest_type(CaRemote *rr, CaDigestType type);
 int ca_remote_get_digest_type(CaRemote *rr, CaDigestType *ret);
 
+int ca_remote_set_log_level(CaRemote *rr, int log_level);
 int ca_remote_set_rate_limit_bps(CaRemote *rr, uint64_t rate_limit_bps);
 
 int ca_remote_set_io_fds(CaRemote *rr, int input_fd, int output_fd);

--- a/src/casync-http.c
+++ b/src/casync-http.c
@@ -534,7 +534,7 @@ static int run(int argc, char *argv[]) {
                 }
 
                 if (curl_easy_setopt(curl, CURLOPT_URL, url_buffer) != CURLE_OK) {
-                        log_error("Failed to set CURL URL to: %s", index_url);
+                        log_error("Failed to set CURL URL to: %s", url_buffer);
                         r = -EIO;
                         goto finish;
                 }

--- a/src/casync-http.c
+++ b/src/casync-http.c
@@ -13,6 +13,7 @@
 
 static volatile sig_atomic_t quit = false;
 
+static int arg_log_level = -1;
 static bool arg_verbose = false;
 static curl_off_t arg_rate_limit_bps = 0;
 
@@ -641,12 +642,13 @@ static int parse_argv(int argc, char *argv[]) {
 
         static const struct option options[] = {
                 { "help",           no_argument,       NULL, 'h'                },
+                { "log-level",      required_argument, NULL, 'l'                },
                 { "verbose",        no_argument,       NULL, 'v'                },
                 { "rate-limit-bps", required_argument, NULL, ARG_RATE_LIMIT_BPS },
                 {}
         };
 
-        int c;
+        int c, r;
 
         assert(argc >= 0);
         assert(argv);
@@ -667,13 +669,22 @@ static int parse_argv(int argc, char *argv[]) {
         if (getenv_bool("CASYNC_VERBOSE") > 0)
                 arg_verbose = true;
 
-        while ((c = getopt_long(argc, argv, "hv", options, NULL)) >= 0) {
+        while ((c = getopt_long(argc, argv, "hl:v", options, NULL)) >= 0) {
 
                 switch (c) {
 
                 case 'h':
                         help();
                         return 0;
+
+                case 'l':
+                        r = set_log_level_from_string(optarg);
+                        if (r < 0)
+                                return log_error_errno(r, "Failed to parse log level \"%s\": %m", optarg);
+
+                        arg_log_level = r;
+
+                        break;
 
                 case 'v':
                         arg_verbose = true;

--- a/src/casync-http.c
+++ b/src/casync-http.c
@@ -465,7 +465,11 @@ static int run(int argc, char *argv[]) {
                 }
         }
 
-        /* (void) curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L); */
+        if (curl_easy_setopt(curl, CURLOPT_VERBOSE, arg_log_level > 4)) {
+                log_error("Failed to set CURL verbosity.");
+                r = -EIO;
+                goto finish;
+        }
 
         if (archive_url) {
                 r = acquire_file(rr, curl, archive_url, write_archive);
@@ -564,6 +568,12 @@ static int run(int argc, char *argv[]) {
                                 r = -EIO;
                                 goto finish;
                         }
+                }
+
+                if (curl_easy_setopt(curl, CURLOPT_VERBOSE, arg_log_level > 4)) {
+                        log_error("Failed to set CURL verbosity.");
+                        r = -EIO;
+                        goto finish;
                 }
 
                 log_debug("Acquiring %s...", url_buffer);

--- a/src/casync-http.c
+++ b/src/casync-http.c
@@ -635,10 +635,14 @@ static void help(void) {
 
 static int parse_argv(int argc, char *argv[]) {
 
+        enum {
+                ARG_RATE_LIMIT_BPS = 0x100,
+        };
+
         static const struct option options[] = {
                 { "help",           no_argument,       NULL, 'h'                },
                 { "verbose",        no_argument,       NULL, 'v'                },
-                { "rate-limit-bps", required_argument, NULL, 'l'                },
+                { "rate-limit-bps", required_argument, NULL, ARG_RATE_LIMIT_BPS },
                 {}
         };
 
@@ -675,7 +679,7 @@ static int parse_argv(int argc, char *argv[]) {
                         arg_verbose = true;
                         break;
 
-                case 'l':
+                case ARG_RATE_LIMIT_BPS:
                         arg_rate_limit_bps = strtoll(optarg, NULL, 10);
                         break;
 

--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -1318,6 +1318,12 @@ static int verb_make(int argc, char *argv[]) {
         if (r < 0)
                 return r;
 
+        if (arg_log_level != -1) {
+                r = ca_sync_set_log_level(s, arg_log_level);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to set log level: %m");
+        }
+
         if (arg_rate_limit_bps != UINT64_MAX) {
                 r = ca_sync_set_rate_limit_bps(s, arg_rate_limit_bps);
                 if (r < 0)
@@ -1615,6 +1621,12 @@ static int verb_extract(int argc, char *argv[]) {
                         if (r < 0 && r != -ENOENT)
                                 log_error_errno(r, "Failed to add existing file as seed %s, ignoring: %m", output);
                 }
+        }
+
+        if (arg_log_level != -1) {
+                r = ca_sync_set_log_level(s, arg_log_level);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to set log level: %m");
         }
 
         if (arg_rate_limit_bps != UINT64_MAX) {
@@ -2772,6 +2784,12 @@ static int verb_mount(int argc, char *argv[]) {
                         return r;
         }
 
+        if (arg_log_level != -1) {
+                r = ca_sync_set_log_level(s, arg_log_level);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to set log level: %m");
+        }
+
         if (arg_rate_limit_bps != UINT64_MAX) {
                 r = ca_sync_set_rate_limit_bps(s, arg_rate_limit_bps);
                 if (r < 0)
@@ -2890,6 +2908,12 @@ static int verb_mkdev(int argc, char *argv[]) {
                 r = set_default_store(input);
                 if (r < 0)
                         goto finish;
+        }
+
+        if (arg_log_level != -1) {
+                r = ca_sync_set_log_level(s, arg_log_level);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to set log level: %m");
         }
 
         if (arg_rate_limit_bps != UINT64_MAX) {
@@ -3453,6 +3477,12 @@ static int verb_pull(int argc, char *argv[]) {
         if (r < 0)
                 return log_error_errno(r, "Failed to set feature flags: %m");
 
+        if (arg_log_level != -1) {
+	        r = ca_remote_set_log_level(rr, arg_log_level);
+        	if (r < 0)
+        		return log_error_errno(r, "Failed to set log level: %m");
+	}
+
         if (arg_rate_limit_bps != UINT64_MAX) {
                 r = ca_remote_set_rate_limit_bps(rr, arg_rate_limit_bps);
                 if (r < 0)
@@ -3605,6 +3635,12 @@ static int verb_push(int argc, char *argv[]) {
                                               (archive_path ? CA_PROTOCOL_WRITABLE_ARCHIVE : 0));
         if (r < 0)
                 log_error_errno(r, "Failed to set feature flags: %m");
+
+        if (arg_log_level != -1) {
+                r = ca_remote_set_log_level(rr, arg_log_level);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to set log level: %m");
+        }
 
         if (arg_rate_limit_bps != UINT64_MAX) {
                 r = ca_remote_set_rate_limit_bps(rr, arg_rate_limit_bps);

--- a/src/casync.h
+++ b/src/casync.h
@@ -31,6 +31,7 @@ CaSync *ca_sync_new_decode(void);
 CaSync *ca_sync_unref(CaSync *sync);
 DEFINE_TRIVIAL_CLEANUP_FUNC(CaSync *, ca_sync_unref);
 
+int ca_sync_set_log_level(CaSync *s, int log_level);
 int ca_sync_set_rate_limit_bps(CaSync *s, uint64_t rate_limit_bps);
 
 int ca_sync_set_feature_flags(CaSync *s, uint64_t flags);


### PR DESCRIPTION
This patchset adds some verbosity to the protocol helpers.

The two first pathes are minor changes.

The third patch propagates the `--log-level` options given to `casync` to `casync-http`. It is based on what is already done for option `--rate-limit-bps`.

The last patch adds some verbosity in libcurl. The HTTP request and response headers are printed to stderr.

```
$ casync --log-level debug extract http://localhost/file.caibx /dev/loop0
Acquiring http://localhost/file.caibx...
*   Trying ::1:80...
* TCP_NODELAY set
* Connected to localhost (::1) port 80 (#0)
> GET /file.caibx HTTP/1.1
Host: localhost
Accept: */*

* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/octet-stream
< Accept-Ranges: bytes
< ETag: "1904834653"
< Last-Modified: Mon, 17 Jun 2019 19:28:35 GMT
< Content-Length: 372224
< Date: Fri, 21 Jun 2019 01:30:23 GMT
< Server: lighttpd/1.4.54
< 
Setting min/avg/max chunk size: 16384 / 65536 / 262144
* Connection #0 to host localhost left intact
(...)
```