### PR TITLE
calocation: fix ESTALE when extracting to regular file

### DIFF
--- a/src/calocation.c
+++ b/src/calocation.c
@@ -572,7 +572,6 @@ int ca_location_open(CaLocation *l) {
 
         if (l->mtime != UINT64_MAX) {
                 struct stat st;
-                uint64_t n;
 
                 /* Ensure inode, mtime and generation still match */
 
@@ -580,10 +579,6 @@ int ca_location_open(CaLocation *l) {
                         return -errno;
 
                 if (st.st_ino != l->inode)
-                        return -ESTALE;
-
-                n = MAX(timespec_to_nsec(st.st_mtim), timespec_to_nsec(st.st_ctim));
-                if (l->mtime != n)
                         return -ESTALE;
 
                 if (l->generation_valid) {


### PR DESCRIPTION
Dear Maintainer(s),

I met the issue discribed below when I want to extract an archive in an existing regular file. Note that it works well if the file is a block device.

I do not think this is the appropriate fix. It is much like a workaround. I need your help to fix it properly.

I would like to know why it is interresting to make such a test on the modification time of the file.

Regards,
Gaël

---

There is an issue when an archive is extracted to a regular file that
exists already.

	# Extract the archive.caibx to dest.bin (dest.bin does not exist yet)
	$ casync extract http://localhost/archive.caibx dest.bin

	# Extract the archive.caibx to existing dest.bin
	$ casync extract http://localhost/archive.caibx dest.bin --log-level debug --verbose
	Acquiring http://localhost/archive.caibx...
	Setting min/avg/max chunk size: 16384 / 65536 / 262144
	Failed to run decoder step: Stale file handle
	Failed to run synchronizer: Stale file handle

The error raised is a difference in the modify time.

In the case of the destination regular file exists (ie. the second call
in the example above), the path goes to several fallocate/write calls
that causes the modification time to be updated and leads to that error.

This commit drops the check for the modification time.