### PR TITLE
src/util: Add Basic Authorization URL Encoding Support

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -421,7 +421,7 @@ static inline int parse_gid(const char *s, gid_t *ret_gid) {
 /* This is a bit more restricted than RFC3986 */
 #define URL_PROTOCOL_FIRST ALPHABET_LOWER
 #define URL_PROTOCOL_CHARSET ALPHABET_LOWER DIGITS "+.-"
-#define HOSTNAME_CHARSET ALPHABET DIGITS "-_."
+#define HOSTNAME_CHARSET ALPHABET DIGITS "-_.%"
 
 int wait_for_terminate(pid_t pid, siginfo_t *status);
 


### PR DESCRIPTION
A client may avoid a login prompt when accessing a basic access authentication by prepending username:password@ to the hostname in the URL. This PR adds support for unsafe ASCII characters in username and password.

P.S. I know that this feauture has been deprecated by RFC 3986, but many users use it.