### PR TITLE
RFC: support streaming a block index' content into a char device

### DIFF
--- a/src/cadecoder.c
+++ b/src/cadecoder.c
@@ -265,7 +265,7 @@ static inline bool CA_DECODER_IS_NAKED(CaDecoder *d) {
 
         return d->n_nodes == 1 &&
                 !d->nodes[0].entry &&
-                (S_ISREG(d->nodes[0].mode) || S_ISBLK(d->nodes[0].mode));
+                (S_ISREG(d->nodes[0].mode) || S_ISBLK(d->nodes[0].mode) || S_ISCHR(d->nodes[0].mode));
 }
 
 static mode_t ca_decoder_node_mode(CaDecoderNode *n) {
@@ -481,13 +481,13 @@ int ca_decoder_set_base_fd(CaDecoder *d, int fd) {
         if (fstatfs(fd, &sfs) < 0)
                 return -errno;
 
-        if (!S_ISREG(st.st_mode) && !S_ISDIR(st.st_mode) && !S_ISBLK(st.st_mode))
+        if (!S_ISREG(st.st_mode) && !S_ISDIR(st.st_mode) && !S_ISBLK(st.st_mode) && !S_ISCHR(st.st_mode))
                 return -ENOTTY;
 
         d->nodes[0] = (CaDecoderNode) {
                 .fd = fd,
                 .entry_offset = S_ISDIR(st.st_mode) ? 0 : UINT64_MAX,
-                .payload_offset = S_ISREG(st.st_mode) || S_ISBLK(st.st_mode) ? 0 : UINT64_MAX,
+                .payload_offset = S_ISREG(st.st_mode) || S_ISBLK(st.st_mode) || S_ISCHR(st.st_mode) ? 0 : UINT64_MAX,
                 .goodbye_offset = UINT64_MAX,
                 .end_offset = UINT64_MAX,
                 .mode = st.st_mode,
@@ -4112,7 +4112,7 @@ static int ca_decoder_step_node(CaDecoder *d, CaDecoderNode *n) {
                 if (mode == (mode_t) -1)
                         return -EUNATCH;
 
-                assert(S_ISREG(mode) || S_ISBLK(mode));
+                assert(S_ISREG(mode) || S_ISBLK(mode) || S_ISCHR(mode));
 
                 /* If the size of this payload is known, and we reached it, we are done */
                 if (n->size != UINT64_MAX) {

--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -1575,16 +1575,16 @@ static int verb_extract(int argc, char *argv[]) {
                                 return -EINVAL;
                         }
 
-                } else if (S_ISREG(st.st_mode) || S_ISBLK(st.st_mode)) {
+                } else if (S_ISREG(st.st_mode) || S_ISBLK(st.st_mode) || S_ISCHR(st.st_mode)) {
 
                         if (operation == _EXTRACT_OPERATION_INVALID)
                                 operation = EXTRACT_BLOB_INDEX;
                         else if (operation != EXTRACT_BLOB_INDEX) {
-                                log_error("Output is a regular file or block device, but attempted to extract an archive.");
+                                log_error("Output is a regular file, block or character device, but attempted to extract an archive.");
                                 return -EINVAL;
                         }
                 } else {
-                        log_error("Output is neither a directory, a regular file, nor a block device. Refusing.");
+                        log_error("Output is neither a directory, a regular file, nor a block or character device. Refusing.");
                         return -EINVAL;
                 }
         }


### PR DESCRIPTION
Within [RAUC](https://rauc.io/) (an updating solution for embedded systems) we want to apply ``casync`` to the usecase of updating UBI volumes whose interface to userspace consists of char devices: to do so the only working solution today without intermediate extraction to a temporary regular file would be to spawn ``casync mkdev <BLOB_INDEX>`` and then to copy the whole contents of the attached ``/dev/nbdX`` over to the UBI volume's char device ``/dev/ubiY_Z``. This is inefficient as the data has to be moved around by ``casync`` first and a second time by the copying mechanism. It would definitively be resource saving if ``casync extract <BLOB_INDEX> /dev/ubiY_Z`` works which is what the pull request's commit finally permits.

As ``casync`` checks the output's file descriptor for belonging to a regular file or a block device several times in the code I am uncertain if there are implicit assumptions in ``casync's`` decoder that I am not aware of and that are breaking down now (that's why I put the _RFC_ in front of the pull request's title). So the question is if my patch is valid at all?

Although what this pull request changes is enough for our usecase it would definitely be appreciated if ``casync extract <BLOB_INDEX>`` could cope with pipes as output, too. Having that feature would allow to manually do things like
```bash
# casync extract <BLOB_INDEX> | ubiupdatevol /dev/ubiY_Z --size=<bytes> -
```
on the commandline. It should be straight forward to extend this patch with ``S_ISFIFO(…)`` correspondingly.