### PR TITLE
Set up Semaphore v2

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,28 @@
+---
+# vi: sw=2 ts=2 et:
+
+version: v1.0
+name: casync
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+# Auto-cancel all running & queued jobs on force-push
+auto_cancel:
+  running:
+    when: "true"
+
+# Cancel all jobs on the first fail
+fail_fast:
+  cancel:
+    when: "true"
+
+blocks:
+  - name: amd64 & i386
+    task:
+      jobs:
+        - name: Build & run
+          commands:
+            - checkout
+            - test/semaphore-run

--- a/test/semaphore-run
+++ b/test/semaphore-run
@@ -19,11 +19,7 @@ set -eu
 (
     set -x
 
-    sudo rm /etc/apt/sources.list.d/*
-
     sudo apt install -y software-properties-common
-    sudo add-apt-repository -y ppa:jonathonf/python-3.6
-    sudo add-apt-repository -y ppa:ginggs/backports
     sudo apt -y update
     sudo apt -y --no-install-recommends install \
          python3.6 \

--- a/test/semaphore-run
+++ b/test/semaphore-run
@@ -19,7 +19,7 @@ set -eu
 (
     set -x
 
-    sudo apt install -y software-properties-common
+    sudo apt install -y gcc-7 libgcc-7-dev software-properties-common
     sudo apt -y update
     sudo apt -y --no-install-recommends install \
          python3.6 \
@@ -71,7 +71,7 @@ echo "============= Installing i386 build dependencies =============="
     sudo apt remove -y libcurl4-openssl-dev
     sudo apt-get install -y --no-install-recommends \
          gcc-multilib \
-         libgcc-5-dev:i386 \
+         libgcc-7-dev:i386 \
          "${DEVPKGS[@]/%/:i386}"
 )
 
@@ -80,7 +80,7 @@ echo "============= Building i386 =============="
 (
     set -x
     export PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu
-    CC=gcc-5 CFLAGS=-m32 LDFLAGS=-m32 meson build-i386
+    CC=gcc-7 CFLAGS=-m32 LDFLAGS=-m32 meson build-i386
     ninja -C build-i386
 )
 

--- a/test/semaphore-run
+++ b/test/semaphore-run
@@ -35,7 +35,7 @@ set -eu
          python3-wheel \
          python-sphinx \
          "${DEVPKGS[@]}"
-    python3.6 -m pip install --user meson ninja
+    sudo python3.6 -m pip install meson ninja
 )
 
 echo


### PR DESCRIPTION
The new version of Semaphore supports newer Ubuntu versions (like Bionic), which should fix the outstanding Python 3.6 issue which was being workarounded by (now broken) custom PPA.

(Sorry for the branch location, but that's how the initial Semaphore setup works)