### PR TITLE
Fix btrfs subvolume detection

### DIFF
--- a/src/cadecoder.c
+++ b/src/cadecoder.c
@@ -3569,7 +3569,7 @@ static int ca_decoder_finalize_child(CaDecoder *d, CaDecoderNode *n, CaDecoderNo
                 return -errno;
 
         if (st.st_dev == d->cached_st_dev)
-                magic = d->cached_st_dev;
+                magic = d->cached_magic;
         else if (child->fd >= 0) {
                 struct statfs sfs;
 


### PR DESCRIPTION
We erroneously use the st_dev value in place of the magic value if the st_dev value is cached. This causes problems extracting trees containing subvolumes.

Fixes #237.