### PR TITLE
casync-http: make the use of .netrc optional

### DIFF
--- a/src/casync-http.c
+++ b/src/casync-http.c
@@ -430,6 +430,12 @@ static int run(int argc, char *argv[]) {
                 goto finish;
         }
 
+        if (curl_easy_setopt(curl, CURLOPT_NETRC, CURL_NETRC_OPTIONAL) != CURLE_OK) {
+                log_error("Failed to make the use of ~/.netrc optional.");
+                r = -EIO;
+                goto finish;
+        }
+
         if (curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L) != CURLE_OK) {
                 log_error("Failed to turn on location following.");
                 r = -EIO;


### PR DESCRIPTION
libcurl ignores the ~/.netrc file by default.

This makes the use of the ~/.netrc file optional; the information in the
URL is preferred.