### PR TITLE
docs: fix simple typo, distuingish -> distinguish

### DIFF
--- a/src/cautil.c
+++ b/src/cautil.c
@@ -37,7 +37,7 @@ bool ca_is_url(const char *s) {
         assert(s);
 
         /* Checks whether something appears to be a URL. This is inspired by RFC3986, but a bit more restricted, so
-         * that we can clearly distuingish URLs from file system paths, and ssh specifications. For example, the kind
+         * that we can clearly distinguish URLs from file system paths, and ssh specifications. For example, the kind
          * of URLs we are interested in must contain '://' as host/path separator.
          *
          * We explicit exclude all strings starting with either "/" or "./" as URL from being detected as URLs, so that

--- a/src/util.c
+++ b/src/util.c
@@ -1081,7 +1081,7 @@ int parse_uid(const char *s, uid_t *ret) {
 
         if (!uid_is_valid(uid))
                 return -ENXIO; /* we return ENXIO instead of EINVAL
-                                * here, to make it easy to distuingish
+                                * here, to make it easy to distinguish
                                 * invalid numeric uids from invalid
                                 * strings. */
 


### PR DESCRIPTION
There is a small typo in src/cautil.c, src/util.c.

Should read `distinguish` rather than `distuingish`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md