### PR TITLE
castore: fix build without lzma or xz

### DIFF
--- a/src/castore.c
+++ b/src/castore.c
@@ -2,7 +2,6 @@
 
 #include <dirent.h>
 #include <fcntl.h>
-#include <lzma.h>
 #include <sys/stat.h>
 #include <unistd.h>
 


### PR DESCRIPTION
castore.c unconditioanlly includes lzma.h, but lzma support if optional.
Furthermore, castore.c does not need anything from lzma.h.

Drop the include altogether.