### PR TITLE
caencoder: remove sys/mount.h to fix build against glibc 2.36

### DIFF
--- a/src/caencoder.c
+++ b/src/caencoder.c
@@ -12,7 +12,6 @@
 #include <string.h>
 #include <sys/acl.h>
 #include <sys/ioctl.h>
-#include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
 #include <sys/xattr.h>


### PR DESCRIPTION
Since glibc 2.36, the mount.h is no longer compatible with the linux mount.h and inclusion of both will cause definition conflicts:

https://sourceware.org/glibc/wiki/Release/2.36#Usage_of_.3Clinux.2Fmount.h.3E_and_.3Csys.2Fmount.h.3E

Fix this by removing inclusion of `sys/mount.h` since inclusion of `linux/fs.h` already pulls in `linux/mount.h`.