### PR TITLE
mtree: prepend "./" to all entries other than "."

### DIFF
--- a/src/casync-tool.c
+++ b/src/casync-tool.c
@@ -1846,6 +1846,13 @@ static int list_one_file(const char *arg0, CaSync *s, bool *toplevel_shown) {
                 (void) ca_sync_current_chattr(s, &flags);
                 (void) ca_sync_current_fat_attrs(s, &fat_attrs);
 
+                /*
+                 * Prepend "./" to every entry other than "." to force them to
+                 * be treated as a Full path. This matches the output of
+                 * "nmtree -C".
+                 */
+                if (!isempty(escaped))
+                        fputs("./", stdout);
                 fputs(empty_to_dot(escaped), stdout);
 
                 if (S_ISLNK(mode))


### PR DESCRIPTION
casync attempts to output all entries as a Full entry but for top-level
entries, there is no "/" in the escaped pathname, resulting in the entry
being treated as a Relative entry.

As per the specification[1], this results in any subsequent Relative
entries (such as top-level files) being treated as children of the
directory which causes manifests produced by casync to fail.

The simplest solution (and the one that "nmtree -C" does) is to prefix
every path with "./". However, nmtree does not like "./." (internally it
requires every entry referenced in an Full entry's path to already have
been referenced in the spec) and so we have to special-case the "."
path.

[1]: https://man.netbsd.org/mtree.5

Ref: https://github.com/vbatts/go-mtree/issues/146
Fixes #167 
Fixes #168
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>