### PR TITLE
src/compressor.h: fix build with gcc >= 13

### DIFF
--- a/src/compressor.h
+++ b/src/compressor.h
@@ -4,6 +4,7 @@
 #define foocompresshorhfoo
 
 #include <stdbool.h>
+#include <stddef.h>
 
 #if HAVE_LIBLZMA
 #  include <lzma.h>


### PR DESCRIPTION
Fix the following build failure with gcc >= 13:

```
In file included from ../src/compressor.c:3:
../src/compressor.h:59:59: error: unknown type name 'size_t'
   59 | int compressor_input(CompressorContext *c, const void *p, size_t sz);
      |                                                           ^~~~~~
../src/compressor.h:19:1: note: 'size_t' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'?
   18 | #include "cacompression.h"
  +++ |+#include <stddef.h>
   19 |

```
Fixes:
 - http://autobuild.buildroot.org/results/ab08f3b90d253db45643dd058b80ae1dd5f49d0f